### PR TITLE
Bump version to 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anylinuxfs-gui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anylinuxfs-gui",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anylinuxfs-gui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anylinuxfs-gui"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "dirs 6.0.0",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anylinuxfs-gui"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "anylinuxfs-gui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "com.anylinuxfs.gui",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.7.4 for the release that includes the whole-disk filesystem fix (#83, merged in #84).