### PR TITLE
Pin svelte-check as devDependency and hold TypeScript <7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@sveltejs/vite-plugin-svelte": "^7",
         "@tauri-apps/cli": "^2",
         "svelte": "^5.55.4",
+        "svelte-check": "^4.7.2",
         "typescript": "^6.0.3",
         "vite": "^8"
       }
@@ -498,6 +499,16 @@
         }
       }
     },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.2.0.tgz",
@@ -883,6 +894,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/clsx": {
@@ -1300,6 +1327,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -1389,6 +1426,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
@@ -1421,6 +1472,19 @@
         "@rolldown/binding-wasm32-wasi": "1.1.3",
         "@rolldown/binding-win32-arm64-msvc": "1.1.3",
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -1481,6 +1545,31 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.2.tgz",
+      "integrity": "sha512-GoS4XJdGswlq0rIT1vtFLzJY1bvHtY37McY9H9Gkm1Ggw/ICdZYn8J/Z8Yi0BEL0i3R4+jtaWVePjyppMlij/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sveltejs/vite-plugin-svelte": "^7",
     "@tauri-apps/cli": "^2",
     "svelte": "^5.55.4",
+    "svelte-check": "^4.7.2",
     "typescript": "^6.0.3",
     "vite": "^8"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript below v7 until svelte-check supports the native rewrite",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
   ]
 }


### PR DESCRIPTION
## Why

CI is currently red on every PR (see #100) because the check step runs bare `npx svelte-check` without svelte-check being a project dependency. npx downloads the latest svelte-check each run and resolves its `typescript` peer dependency to the newest release — which is now TypeScript 7 (the native rewrite). svelte-check 4.x crashes on startup with it:

```
TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
```

## What

- Add `svelte-check` to `devDependencies` so `npx svelte-check` uses the local, lockfile-controlled install with the project's TypeScript 6.0.3.
- Add a Renovate rule holding `typescript` below v7 until the Svelte toolchain supports it (replaces #99, which also has a broken lockfile from a failed `renovate/artifacts` step).

Verified locally: `npx svelte-check` passes with 215 files, 0 errors.