### PR TITLE
feat: add interactive Terminal elevation for managed macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ Interactive mount commands use macOS `script -q /dev/null` as a bidirectional ps
 
 Interactive Terminal mode never opens a window for automatic background refreshes. With Admin mode enabled, click **Refresh** when disks are connected or removed. A pending mount can be cancelled from the GUI; the app terminates its Terminal handoff and requests device-specific cleanup. This mode does not bypass organizational policy: the privilege manager can still approve or deny each command.
 
-The Rust backend owns and persists the elevation setting. For a dedicated managed-Mac build, enable the enforcement feature to lock Interactive Terminal mode; no matching frontend build flag is required:
-
-```bash
-npx tauri build --features managed-terminal-elevation
-```
+The Rust backend owns and persists the elevation setting. It cannot be changed while a privileged operation is active, so the authentication and cancellation behavior remain stable until that operation finishes.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ xattr -cr /Applications/anylinuxfs-gui.app
 
 Then you can open the app normally.
 
+## Administrator authentication
+
+The default **Native sudo** mode uses cached/native PAM authentication and falls back to the app's password dialog. This works for normal macOS administrator accounts.
+
+For managed Macs where an endpoint privilege manager requires an interactive terminal, open **Preferences → Administrator authentication** and select **Interactive Terminal (managed Macs)**. Admin scans and mount operations then open an owner-only temporary `.command` file in Terminal. Complete the organization's approval or justification prompt there. LUKS and BitLocker secrets are requested directly by `anylinuxfs` in Terminal; they are not placed in the generated command file or its environment.
+
+Interactive mount commands use macOS `script -q /dev/null` as a bidirectional pseudo-terminal relay and are not piped through an output-capture process. Terminal echo is disabled before the command and restored by a cleanup trap. This is required for endpoint privilege managers that place an elevated child on another pseudo-terminal, and prevents encryption secrets from being echoed or written to a handoff transcript. Output capture remains enabled only for non-secret discovery commands such as `list`.
+
+Interactive Terminal mode never opens a window for automatic background refreshes. With Admin mode enabled, click **Refresh** when disks are connected or removed. A pending mount can be cancelled from the GUI; the app terminates its Terminal handoff and requests device-specific cleanup. This mode does not bypass organizational policy: the privilege manager can still approve or deny each command.
+
+The Rust backend owns and persists the elevation setting. For a dedicated managed-Mac build, enable the enforcement feature to lock Interactive Terminal mode; no matching frontend build flag is required:
+
+```bash
+npx tauri build --features managed-terminal-elevation
+```
+
 ## Screenshots
 
 <picture>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2021"
 name = "anylinuxfs_gui_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+default = []
+# Build flavor for Macs whose privilege-management software only intercepts
+# interactive sudo commands launched from Terminal.
+managed-terminal-elevation = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,12 +7,6 @@ edition = "2021"
 name = "anylinuxfs_gui_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
-[features]
-default = []
-# Build flavor for Macs whose privilege-management software only intercepts
-# interactive sudo commands launched from Terminal.
-managed-terminal-elevation = []
-
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -204,11 +204,12 @@ pub fn execute_command_with_elevation(
     needs_sudo: bool,
     passphrase: Option<&str>,
     silent: bool,
+    elevation_mode: ElevationMode,
     elevation_state: &ElevationState,
     terminal_interaction: TerminalInteraction,
 ) -> Result<String, CommandExecutionError> {
     if needs_sudo {
-        match elevation_state.mode() {
+        match elevation_mode {
             ElevationMode::Native => execute_with_sudo(args, passphrase, silent)
                 .map_err(|error| {
                     if error == "ALFS_SILENT_AUTH_EXPIRED" {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -4,6 +4,29 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use std::sync::OnceLock;
+use crate::elevation::{
+    execute_in_terminal, ElevationMode, ElevationState, TerminalExecutionError,
+    TerminalInteraction,
+};
+
+#[derive(Debug, Clone)]
+pub enum CommandExecutionError {
+    InteractionRequired,
+    Cancelled,
+    TimedOut,
+    Failed(String),
+}
+
+impl CommandExecutionError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::InteractionRequired => "ALFS_SILENT_AUTH_EXPIRED".to_string(),
+            Self::Cancelled => "Interactive Terminal operation was cancelled".to_string(),
+            Self::TimedOut => "Interactive Terminal operation timed out".to_string(),
+            Self::Failed(message) => message.clone(),
+        }
+    }
+}
 
 /// Sanitize error output to avoid exposing sensitive system details
 /// Logs the full error for debugging but returns a user-friendly message
@@ -21,6 +44,9 @@ fn sanitize_error(stdout: &str, stderr: &str) -> String {
     }
     if combined.contains("Permission denied") {
         return "Permission denied - try running with administrator privileges".to_string();
+    }
+    if combined.contains("Execution blocked") || combined.contains("does not have Admin rights") {
+        return "Administrator elevation was blocked by system policy".to_string();
     }
     if combined.contains("Device busy") || combined.contains("resource busy") {
         return "Device is busy - close any applications using it and try again".to_string();
@@ -169,6 +195,53 @@ pub fn execute_command(args: &[&str], needs_sudo: bool, passphrase: Option<&str>
         execute_with_sudo(args, passphrase, silent)
     } else {
         execute_direct(args, passphrase)
+    }
+}
+
+/// Execute an anylinuxfs command using the Rust-owned elevation policy.
+pub fn execute_command_with_elevation(
+    args: &[&str],
+    needs_sudo: bool,
+    passphrase: Option<&str>,
+    silent: bool,
+    elevation_state: &ElevationState,
+    terminal_interaction: TerminalInteraction,
+) -> Result<String, CommandExecutionError> {
+    if needs_sudo {
+        match elevation_state.mode() {
+            ElevationMode::Native => execute_with_sudo(args, passphrase, silent)
+                .map_err(|error| {
+                    if error == "ALFS_SILENT_AUTH_EXPIRED" {
+                        CommandExecutionError::InteractionRequired
+                    } else {
+                        CommandExecutionError::Failed(error)
+                    }
+                }),
+            ElevationMode::InteractiveTerminal => execute_in_terminal(
+                elevation_state,
+                get_anylinuxfs_path().ok_or_else(|| {
+                    CommandExecutionError::Failed(
+                        "anylinuxfs CLI not found in PATH or standard locations".to_string(),
+                    )
+                })?,
+                args,
+                silent,
+                terminal_interaction,
+            )
+            .map_err(|error| match error {
+                TerminalExecutionError::InteractionRequired => {
+                    CommandExecutionError::InteractionRequired
+                }
+                TerminalExecutionError::Cancelled => CommandExecutionError::Cancelled,
+                TerminalExecutionError::TimedOut => CommandExecutionError::TimedOut,
+                TerminalExecutionError::CommandFailed { output, .. } if !output.is_empty() => {
+                    CommandExecutionError::Failed(sanitize_error(&output, ""))
+                }
+                other => CommandExecutionError::Failed(other.to_string()),
+            }),
+        }
+    } else {
+        execute_direct(args, passphrase).map_err(CommandExecutionError::Failed)
     }
 }
 
@@ -390,4 +463,18 @@ osascript -e 'Tell application "System Events" to display dialog "anylinuxfs req
         .map_err(|e| format!("Failed to persist askpass script: {}", e))?;
 
     Ok(path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_privilege_denial_has_a_specific_error() {
+        let message = sanitize_error(
+            "Execution blocked: user does not have Admin rights",
+            "",
+        );
+        assert_eq!(message, "Administrator elevation was blocked by system policy");
+    }
 }

--- a/src-tauri/src/commands/disk.rs
+++ b/src-tauri/src/commands/disk.rs
@@ -695,7 +695,7 @@ pub async fn mount_disk(
         }
 
         // Check if mount command finished with an error
-        if let Some(ref result) = *mount_result.lock().unwrap() {
+        let mount_command_succeeded = if let Some(ref result) = *mount_result.lock().unwrap() {
             let output_text = match result {
                 Ok(out) => out.clone(),
                 Err(error) => error.message(),
@@ -731,11 +731,15 @@ pub async fn mount_disk(
                     other => MountCommandResult::new(MountOutcome::Failed, other.message()),
                 });
             }
-        }
+            true
+        } else {
+            false
+        };
 
         // Check if this specific device appeared in `anylinuxfs status`
-        if check_device_mounted(&device) {
-            elevation_state.mark_mount_persistent(&device);
+        if check_device_mounted(&device)
+            && (mount_command_succeeded || elevation_state.mark_mount_persistent(&device))
+        {
             let _ = app.emit("status-changed", ());
             return Ok(MountCommandResult::new(
                 MountOutcome::Mounted,

--- a/src-tauri/src/commands/disk.rs
+++ b/src-tauri/src/commands/disk.rs
@@ -93,9 +93,9 @@ pub async fn list_disks(
     silent: bool,
 ) -> Result<DiskListResult, String> {
     let elevation_state = elevation_state.inner().clone();
-    let timeout_secs = if use_sudo
-        && elevation_state.mode() == ElevationMode::InteractiveTerminal
-    {
+    let operation_guard = elevation_state.begin_operation("list")?;
+    let elevation_mode = operation_guard.mode();
+    let timeout_secs = if use_sudo && elevation_mode == ElevationMode::InteractiveTerminal {
         INTERACTIVE_ELEVATION_TIMEOUT_SECS
     } else {
         COMMAND_TIMEOUT_SECS
@@ -110,6 +110,7 @@ pub async fn list_disks(
             use_sudo,
             None,
             silent,
+            elevation_mode,
             &list_elevation_state,
             TerminalInteraction::CaptureOutput {
                 operation: "list".to_string(),
@@ -598,9 +599,9 @@ pub async fn mount_disk(
     // Validate device path before use
     validate_device_path(&device)?;
     let elevation_state = elevation_state.inner().clone();
-    let elevation_mode = elevation_state.mode();
     let operation = format!("mount:{}", device);
-    let _operation_guard = elevation_state.begin_operation(operation.clone())?;
+    let operation_guard = elevation_state.begin_operation(operation.clone())?;
+    let elevation_mode = operation_guard.mode();
 
     // Sanitize extra_options with a whitelist to prevent command injection
     if let Some(ref opts) = extra_options {
@@ -661,6 +662,7 @@ pub async fn mount_disk(
                 true,
                 pass_ref,
                 false,
+                elevation_mode,
                 &mount_elevation_state,
                 TerminalInteraction::SecretPrompt {
                     operation: mount_operation,

--- a/src-tauri/src/commands/disk.rs
+++ b/src-tauri/src/commands/disk.rs
@@ -1,11 +1,18 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::time::timeout;
 use crate::cache;
-use crate::cli::execute_command;
+use crate::cli::{
+    execute_command, execute_command_with_elevation, CommandExecutionError,
+};
+use crate::elevation::{
+    ElevationMode, ElevationState, TerminalInteraction,
+    INTERACTIVE_ELEVATION_TIMEOUT_SECS,
+};
 use crate::paths::{COMMAND_TIMEOUT_SECS, MOUNT_TIMEOUT_SECS};
 
 /// Validate device path to prevent command injection
@@ -80,11 +87,35 @@ pub struct DiskListResult {
 }
 
 #[tauri::command]
-pub async fn list_disks(use_sudo: bool, silent: bool) -> Result<DiskListResult, String> {
+pub async fn list_disks(
+    elevation_state: tauri::State<'_, Arc<ElevationState>>,
+    use_sudo: bool,
+    silent: bool,
+) -> Result<DiskListResult, String> {
+    let elevation_state = elevation_state.inner().clone();
+    let timeout_secs = if use_sudo
+        && elevation_state.mode() == ElevationMode::InteractiveTerminal
+    {
+        INTERACTIVE_ELEVATION_TIMEOUT_SECS
+    } else {
+        COMMAND_TIMEOUT_SECS
+    };
+    let list_elevation_state = elevation_state.clone();
+
     // Run in blocking task with timeout to avoid freezing UI
     let list_future = tokio::task::spawn_blocking(move || {
         // Run list command (now shows all volumes by default, including broken SD cards)
-        let output = execute_command(&["list"], use_sudo, None, silent)?;
+        let output = execute_command_with_elevation(
+            &["list"],
+            use_sudo,
+            None,
+            silent,
+            &list_elevation_state,
+            TerminalInteraction::CaptureOutput {
+                operation: "list".to_string(),
+            },
+        )
+        .map_err(|error| error.message())?;
         let mut result = parse_disk_list_output(&output)?;
 
         // Check which partitions are already mounted by the system
@@ -102,10 +133,14 @@ pub async fn list_disks(use_sudo: bool, silent: bool) -> Result<DiskListResult, 
         Ok(result)
     });
 
-    timeout(Duration::from_secs(COMMAND_TIMEOUT_SECS), list_future)
-        .await
-        .map_err(|_| format!("List disks timed out after {} seconds", COMMAND_TIMEOUT_SECS))?
-        .map_err(|e| format!("Task error: {}", e))?
+    match timeout(Duration::from_secs(timeout_secs), list_future).await {
+        Ok(result) => result
+            .map_err(|error| format!("Task error: {}", error))?,
+        Err(_) => {
+            elevation_state.cancel_pending_operation("list");
+            Err(format!("List disks timed out after {} seconds", timeout_secs))
+        }
+    }
 }
 
 fn update_mount_status(result: &mut DiskListResult) {
@@ -525,10 +560,47 @@ fn parse_type_and_name(parts: &[&str]) -> (String, Option<String>) {
     ("unknown".to_string(), None)
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MountOutcome {
+    Mounted,
+    EncryptionRequired,
+    Cancelled,
+    TimedOut,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MountCommandResult {
+    pub outcome: MountOutcome,
+    pub message: Option<String>,
+}
+
+impl MountCommandResult {
+    fn new(outcome: MountOutcome, message: impl Into<Option<String>>) -> Self {
+        Self {
+            outcome,
+            message: message.into(),
+        }
+    }
+}
+
 #[tauri::command]
-pub async fn mount_disk(app: AppHandle, device: String, passphrase: Option<String>, read_only: Option<bool>, extra_options: Option<String>, ignore_permissions: Option<bool>) -> Result<String, String> {
+pub async fn mount_disk(
+    app: AppHandle,
+    elevation_state: tauri::State<'_, Arc<ElevationState>>,
+    device: String,
+    passphrase: Option<String>,
+    read_only: Option<bool>,
+    extra_options: Option<String>,
+    ignore_permissions: Option<bool>,
+) -> Result<MountCommandResult, String> {
     // Validate device path before use
     validate_device_path(&device)?;
+    let elevation_state = elevation_state.inner().clone();
+    let elevation_mode = elevation_state.mode();
+    let operation = format!("mount:{}", device);
+    let _operation_guard = elevation_state.begin_operation(operation.clone())?;
 
     // Sanitize extra_options with a whitelist to prevent command injection
     if let Some(ref opts) = extra_options {
@@ -557,13 +629,23 @@ pub async fn mount_disk(app: AppHandle, device: String, passphrase: Option<Strin
     // Spawn the mount command in a background thread so we can poll status
     // concurrently — the mount appears in Finder before the command exits
     let mount_device = device.clone();
-    let mount_result: std::sync::Arc<std::sync::Mutex<Option<Result<String, String>>>> =
+    let mount_operation = operation.clone();
+    let mount_elevation_state = elevation_state.clone();
+    let mount_result: std::sync::Arc<
+        std::sync::Mutex<Option<Result<String, CommandExecutionError>>>,
+    > =
         std::sync::Arc::new(std::sync::Mutex::new(None));
     let mount_result_bg = mount_result.clone();
 
     let _mount_thread = tokio::task::spawn_blocking(move || {
-        let effective_passphrase = passphrase.unwrap_or_else(|| "##PROBE##".to_string());
-        let pass_ref = Some(effective_passphrase.as_str());
+        // Interactive Terminal elevation prompts there. Never place a disk
+        // passphrase in a generated command file or process environment.
+        let effective_passphrase = if elevation_mode == ElevationMode::InteractiveTerminal {
+            None
+        } else {
+            Some(passphrase.unwrap_or_else(|| "##PROBE##".to_string()))
+        };
+        let pass_ref = effective_passphrase.as_deref();
 
         let result = {
             let mut args: Vec<&str> = vec!["mount"];
@@ -574,7 +656,16 @@ pub async fn mount_disk(app: AppHandle, device: String, passphrase: Option<Strin
                 args.extend_from_slice(&["-o", combined]);
             }
             args.push(&mount_device);
-            execute_command(&args, true, pass_ref, false)
+            execute_command_with_elevation(
+                &args,
+                true,
+                pass_ref,
+                false,
+                &mount_elevation_state,
+                TerminalInteraction::SecretPrompt {
+                    operation: mount_operation,
+                },
+            )
         };
 
         *mount_result_bg.lock().unwrap() = Some(result);
@@ -588,9 +679,15 @@ pub async fn mount_disk(app: AppHandle, device: String, passphrase: Option<Strin
             || lower.contains("encrypted") || lower.contains("wrong key")
     };
 
-    // Poll `anylinuxfs status` concurrently while mount command runs
-    // 120 retries × 500ms = 60 seconds total timeout
-    for i in 0..120 {
+    // Poll `anylinuxfs status` concurrently while mount command runs. Interactive
+    // elevation gets a longer window for approval and a disk passphrase.
+    let mount_timeout_secs = if elevation_mode == ElevationMode::InteractiveTerminal {
+        INTERACTIVE_ELEVATION_TIMEOUT_SECS
+    } else {
+        MOUNT_TIMEOUT_SECS
+    };
+    let retries = mount_timeout_secs * 2;
+    for i in 0..retries {
         if i > 0 {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
@@ -599,29 +696,61 @@ pub async fn mount_disk(app: AppHandle, device: String, passphrase: Option<Strin
         if let Some(ref result) = *mount_result.lock().unwrap() {
             let output_text = match result {
                 Ok(out) => out.clone(),
-                Err(e) => e.clone(),
+                Err(error) => error.message(),
             };
             if is_encryption_error(&output_text) {
                 // Clean up leftover VM from the failed probe attempt
-                let _ = execute_command(&["stop"], true, None, false);
+                let _ = execute_command(&["stop", &device], false, None, false);
                 let _ = app.emit("status-changed", ());
-                return Err("ENCRYPTION_REQUIRED: This partition is encrypted. A passphrase is needed to mount it.".to_string());
+                if elevation_mode == ElevationMode::InteractiveTerminal {
+                    return Ok(MountCommandResult::new(
+                        MountOutcome::Failed,
+                        output_text,
+                    ));
+                }
+                return Ok(MountCommandResult::new(
+                    MountOutcome::EncryptionRequired,
+                    "This partition is encrypted. A passphrase is needed to mount it."
+                        .to_string(),
+                ));
             }
-            if result.is_err() {
+            if let Err(error) = result {
                 let _ = app.emit("status-changed", ());
-                return Err(result.as_ref().unwrap_err().clone());
+                return Ok(match error {
+                    CommandExecutionError::Cancelled => MountCommandResult::new(
+                        MountOutcome::Cancelled,
+                        "Mount cancelled".to_string(),
+                    ),
+                    CommandExecutionError::TimedOut => MountCommandResult::new(
+                        MountOutcome::TimedOut,
+                        "Interactive Terminal mount timed out and cleanup was requested."
+                            .to_string(),
+                    ),
+                    other => MountCommandResult::new(MountOutcome::Failed, other.message()),
+                });
             }
         }
 
         // Check if this specific device appeared in `anylinuxfs status`
         if check_device_mounted(&device) {
+            elevation_state.mark_mount_persistent(&device);
             let _ = app.emit("status-changed", ());
-            return Ok("Mounted successfully".to_string());
+            return Ok(MountCommandResult::new(
+                MountOutcome::Mounted,
+                Some("Mounted successfully".to_string()),
+            ));
         }
     }
 
+    elevation_state.cancel_active_mount(&device);
     let _ = app.emit("status-changed", ());
-    Err(format!("Mount operation timed out after {} seconds", MOUNT_TIMEOUT_SECS))
+    Ok(MountCommandResult::new(
+        MountOutcome::TimedOut,
+        format!(
+            "Mount operation timed out after {} seconds and cleanup was requested.",
+            mount_timeout_secs
+        ),
+    ))
 }
 
 fn check_device_mounted(device: &str) -> bool {
@@ -762,5 +891,16 @@ mod tests {
 
         let devices: Vec<&str> = disk.partitions.iter().map(|p| p.device.as_str()).collect();
         assert_eq!(devices, vec!["/dev/disk6s1", "/dev/disk6s5"]);
+    }
+
+    #[test]
+    fn mount_outcomes_have_a_stable_frontend_shape() {
+        let result = MountCommandResult::new(
+            MountOutcome::TimedOut,
+            "Cleanup was requested".to_string(),
+        );
+        let json = serde_json::to_value(result).expect("mount result should serialize");
+        assert_eq!(json["outcome"], "timed_out");
+        assert_eq!(json["message"], "Cleanup was requested");
     }
 }

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -69,6 +69,7 @@ struct TerminalSession {
     status_path: PathBuf,
     cli_path: PathBuf,
     persistent_mount: bool,
+    cancellation_started: bool,
 }
 
 pub struct ElevationState {
@@ -157,6 +158,13 @@ impl ElevationState {
         cli_path: PathBuf,
     ) -> (u64, bool) {
         let id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
+        // Hold cancellation requests through insertion so a request either
+        // marks this session now or finds it in `cancel_matching` afterward.
+        let mut cancellation_requests = self
+            .cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let cancellation_requested = cancellation_requests.remove(&operation);
         let session = TerminalSession {
             operation: operation.clone(),
             cancel_path,
@@ -165,22 +173,18 @@ impl ElevationState {
             status_path,
             cli_path,
             persistent_mount: false,
+            cancellation_started: cancellation_requested,
         };
         self.sessions
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(id, session.clone());
+        drop(cancellation_requests);
 
-        // A UI cancellation can arrive after mount_disk starts but just before
-        // Terminal registration. Consume that request here so no command is
-        // launched after the user has cancelled it.
-        let cancellation_requested = self
-            .cancellation_requests
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&operation);
         if cancellation_requested {
-            cancel_terminal_session(&session);
+            // The command has not been launched yet, so only mark the handoff
+            // cancelled. Stopping the device here could affect an older mount.
+            cancel_terminal_session(&session, false);
         }
         (id, cancellation_requested)
     }
@@ -192,18 +196,36 @@ impl ElevationState {
             .remove(&id);
     }
 
-    pub fn mark_mount_persistent(&self, device: &str) {
+    pub fn mark_mount_persistent(&self, device: &str) -> bool {
         let operation = format!("mount:{}", device);
-        for session in self
+        let cancellation_requests = self
+            .cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if cancellation_requests.contains(&operation) {
+            return false;
+        }
+        let mut sessions = self
             .sessions
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .values_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some((_, session)) = sessions
+            .iter_mut()
+            .filter(|(_, session)| session.operation == operation)
+            .max_by_key(|(id, _)| **id)
         {
-            if session.operation == operation {
-                session.persistent_mount = true;
+            if session.cancellation_started {
+                return false;
             }
+            session.persistent_mount = true;
+            return true;
         }
+        drop(sessions);
+        drop(cancellation_requests);
+
+        // Native elevation has no Terminal session to preserve. Interactive
+        // callers must separately prove that a completed command succeeded.
+        self.mode() != ElevationMode::InteractiveTerminal
     }
 
     pub fn begin_operation(
@@ -280,20 +302,29 @@ impl ElevationState {
         self.cancel_matching(None, false)
     }
 
-    fn cancel_session(&self, id: u64) -> bool {
-        let session = self
+    /// Returns true when a confirmed mount must be preserved. The persistence
+    /// check and session snapshot share one lock so timeout cleanup cannot race
+    /// `mark_mount_persistent` after observing a stale value.
+    fn cancel_session_for_timeout(&self, id: u64) -> bool {
+        let mut sessions = self
             .sessions
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(&id)
-            .cloned();
-
-        if let Some(session) = session {
-            cancel_terminal_session(&session);
-            true
-        } else {
-            false
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(session) = sessions.get_mut(&id) else {
+            return false;
+        };
+        if session.persistent_mount {
+            return true;
         }
+        if session.cancellation_started {
+            return false;
+        }
+        session.cancellation_started = true;
+        let session = session.clone();
+        drop(sessions);
+
+        cancel_terminal_session(&session, true);
+        false
     }
 
     fn cancel_matching(&self, operation: Option<&str>, include_persistent: bool) -> usize {
@@ -301,18 +332,24 @@ impl ElevationState {
             .sessions
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .values()
-            .filter(|session| {
-                (include_persistent || !session.persistent_mount)
+            .values_mut()
+            .filter_map(|session| {
+                if (include_persistent || !session.persistent_mount)
+                    && !session.cancellation_started
                     && operation
                         .map(|value| value == session.operation.as_str())
                         .unwrap_or(true)
+                {
+                    session.cancellation_started = true;
+                    Some(session.clone())
+                } else {
+                    None
+                }
             })
-            .cloned()
             .collect();
 
         for session in &sessions {
-            cancel_terminal_session(session);
+            cancel_terminal_session(session, true);
         }
         sessions.len()
     }
@@ -381,8 +418,17 @@ fn terminal_script_content(
         r#"#!/bin/zsh
 /usr/bin/printf '%s\n' "$$" > {pid_temp_path}
 /bin/mv -f {pid_temp_path} {pid_path}
-/usr/bin/printf '%s\n' "launched" > {launch_ack_temp_path}
-/bin/mv -f {launch_ack_temp_path} {launch_ack_path}
+start_gate_owned=0
+acquire_start_gate() {{
+  while ! /bin/mkdir {start_gate_path} 2>/dev/null; do /bin/sleep 0.01; done
+  start_gate_owned=1
+}}
+release_start_gate() {{
+  if [[ "$start_gate_owned" == "1" ]]; then
+    /bin/rmdir {start_gate_path} 2>/dev/null
+    start_gate_owned=0
+  fi
+}}
 restore_terminal_echo() {{ /bin/stty echo 2>/dev/null }}
 finish_terminal() {{
   command_status="$1"
@@ -390,18 +436,24 @@ finish_terminal() {{
   [[ -e {cancel_path} ]] && completion="cancelled"
   /usr/bin/printf '%s\n%s\n' "$command_status" "$completion" > {status_temp_path}
   /bin/mv -f {status_temp_path} {status_path}
+  release_start_gate
   restore_terminal_echo
 }}
 trap 'finish_terminal 130; exit 130' HUP INT TERM
+acquire_start_gate
 if [[ -e {cancel_path} ]]; then
   finish_terminal 130
   exit 130
 fi
+/usr/bin/printf '%s\n' "command-starting" > {launch_ack_temp_path}
+/bin/mv -f {launch_ack_temp_path} {launch_ack_path}
+release_start_gate
 "#,
         pid_path = shell_quote(&pid_path.to_string_lossy()),
         pid_temp_path = shell_quote(&format!("{}.tmp", pid_path.to_string_lossy())),
         launch_ack_path = shell_quote(&launch_ack_path.to_string_lossy()),
         launch_ack_temp_path = shell_quote(&format!("{}.tmp", launch_ack_path.to_string_lossy())),
+        start_gate_path = shell_quote(&cancel_path.with_file_name("start-gate").to_string_lossy()),
         cancel_path = shell_quote(&cancel_path.to_string_lossy()),
         status_path = shell_quote(&status_path.to_string_lossy()),
         status_temp_path = shell_quote(&format!("{}.tmp", status_path.to_string_lossy())),
@@ -589,38 +641,60 @@ fn wait_for_terminal_result(
             return Err(TerminalExecutionError::Cancelled);
         }
         if start.elapsed() > timeout {
-            state.cancel_session(session_id);
+            if state.cancel_session_for_timeout(session_id) {
+                // The mount is already available to the user. Its detached VM
+                // can still be a descendant if the CLI parent is hung, so do
+                // not signal this hierarchy or request device cleanup.
+                return Ok(fs::read_to_string(output_path).unwrap_or_default());
+            }
             return Err(TerminalExecutionError::TimedOut);
         }
         std::thread::sleep(Duration::from_millis(100));
     }
 }
 
-fn cancel_terminal_session(session: &TerminalSession) {
+fn cancel_terminal_session(session: &TerminalSession, cleanup_mount: bool) {
+    // Serialize the cancel marker with the script's final pre-command check.
+    // Whichever side acquires the gate first determines whether the command is
+    // committed to start and therefore whether device cleanup is appropriate.
+    let start_gate_path = session.cancel_path.with_file_name("start-gate");
+    let gate_acquired = acquire_start_gate(&start_gate_path, Duration::from_secs(1));
     if let Err(error) = fs::write(&session.cancel_path, b"cancelled\n") {
         log::warn!("Failed to mark Terminal session cancelled: {}", error);
     }
-
-    if let Ok(pid_text) = fs::read_to_string(&session.pid_path) {
-        if let Ok(pid) = pid_text.trim().parse::<u32>() {
-            if pid > 1 {
-                let _ = Command::new("/usr/bin/pkill")
-                    .args(["-TERM", "-P", &pid.to_string()])
-                    .status();
-                let _ = Command::new("/bin/kill")
-                    .args(["-TERM", &pid.to_string()])
-                    .status();
-            }
-        }
+    let command_started = session.launch_ack_path.exists();
+    if gate_acquired {
+        let _ = fs::remove_dir(&start_gate_path);
     }
 
-    if let Some(device) = session.operation.strip_prefix("mount:") {
-        let _ = Command::new(&session.cli_path)
-            .args(["stop", device])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn();
+    if let Some(pid) = read_session_pid(&session.pid_path).filter(|pid| *pid > 1) {
+        terminate_process_tree(session, pid);
+    }
+
+    if cleanup_mount && command_started {
+        if let Some(device) = session.operation.strip_prefix("mount:") {
+            request_device_cleanup(session, device);
+        }
+    }
+}
+
+fn acquire_start_gate(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match fs::create_dir(path) {
+            Ok(()) => return true,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if Instant::now() >= deadline {
+                    log::warn!("Timed out waiting for Terminal command start gate");
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => {
+                log::warn!("Failed to acquire Terminal command start gate: {}", error);
+                return false;
+            }
+        }
     }
 }
 
@@ -652,23 +726,7 @@ fn ensure_terminal_session_stopped(state: &ElevationState, id: u64) {
         return;
     }
 
-    for _ in 0..20 {
-        if !process_exists(pid) {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-
-    log::warn!(
-        "Terminal elevation shell {} did not stop after cancellation; forcing termination",
-        pid
-    );
-    let _ = Command::new("/usr/bin/pkill")
-        .args(["-KILL", "-P", &pid.to_string()])
-        .status();
-    let _ = Command::new("/bin/kill")
-        .args(["-KILL", &pid.to_string()])
-        .status();
+    terminate_process_tree(&session, pid);
 }
 
 fn read_session_pid(path: &Path) -> Option<u32> {
@@ -688,14 +746,164 @@ fn wait_for_terminal_session_pid(session: &TerminalSession, timeout: Duration) -
     }
 }
 
-fn process_exists(pid: u32) -> bool {
-    Command::new("/bin/kill")
-        .args(["-0", &pid.to_string()])
+fn child_process_ids(parent_pid: u32) -> Vec<u32> {
+    let output = Command::new("/usr/bin/pgrep")
+        .args(["-P", &parent_pid.to_string()])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .filter(|pid| *pid > 1)
+        .collect()
+}
+
+fn process_tree(root_pid: u32) -> Vec<u32> {
+    fn collect(pid: u32, seen: &mut HashSet<u32>, result: &mut Vec<u32>) {
+        for child in child_process_ids(pid) {
+            if seen.insert(child) {
+                collect(child, seen, result);
+                result.push(child);
+            }
+        }
+    }
+
+    let mut seen = HashSet::from([root_pid]);
+    let mut result = Vec::new();
+    collect(root_pid, &mut seen, &mut result);
+    result.push(root_pid);
+    result
+}
+
+fn signal_processes(pids: &[u32], signal: &str) {
+    for pid in pids {
+        let _ = Command::new("/bin/kill")
+            .args([signal, &pid.to_string()])
+            .status();
+    }
+}
+
+fn process_identity(pid: u32) -> Option<String> {
+    let output = Command::new("/bin/ps")
+        .args(["-p", &pid.to_string(), "-o", "lstart=", "-o", "command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!identity.is_empty()).then_some(identity)
+}
+
+fn recorded_terminal_shell_matches(session: &TerminalSession, pid: u32) -> bool {
+    let Some(work_dir) = session.pid_path.parent() else {
+        return false;
+    };
+    let expected_script = work_dir.join("run-anylinuxfs.command");
+    let output = Command::new("/bin/ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains(expected_script.to_string_lossy().as_ref())
+}
+
+fn terminate_process_tree(session: &TerminalSession, root_pid: u32) {
+    if root_pid <= 1 {
+        return;
+    }
+    if !recorded_terminal_shell_matches(session, root_pid) {
+        log::warn!(
+            "Refusing to terminate stale or unexpected Terminal shell PID {}",
+            root_pid
+        );
+        return;
+    }
+
+    // Snapshot descendants before terminating their parents so reparenting
+    // cannot make deeper `script`/`sudo`/CLI processes invisible to cleanup.
+    let pids = process_tree(root_pid);
+    let identities: Vec<(u32, String)> = pids
+        .iter()
+        .filter_map(|pid| process_identity(*pid).map(|identity| (*pid, identity)))
+        .collect();
+    signal_processes(&pids, "-TERM");
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        if identities
+            .iter()
+            .all(|(pid, identity)| process_identity(*pid).as_ref() != Some(identity))
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let remaining: Vec<u32> = identities
+        .iter()
+        .filter_map(|(pid, identity)| {
+            (process_identity(*pid).as_ref() == Some(identity)).then_some(*pid)
+        })
+        .collect();
+    if remaining.is_empty() {
+        return;
+    }
+
+    log::warn!(
+        "{} Terminal elevation process(es) ignored cancellation; forcing termination",
+        remaining.len()
+    );
+    signal_processes(&remaining, "-KILL");
+}
+
+fn request_device_cleanup(session: &TerminalSession, device: &str) {
+    let child = Command::new(&session.cli_path)
+        .args(["stop", device])
+        .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .spawn();
+    let Ok(mut child) = child else {
+        log::warn!("Failed to start cleanup for cancelled mount {}", device);
+        return;
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    log::warn!(
+                        "Cleanup for cancelled mount {} failed with status {}",
+                        device,
+                        status
+                    );
+                }
+                return;
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(None) => {
+                log::warn!("Cleanup for cancelled mount {} timed out", device);
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            Err(error) => {
+                log::warn!(
+                    "Failed while waiting for cancelled mount {} cleanup: {}",
+                    device,
+                    error
+                );
+                return;
+            }
+        }
+    }
 }
 
 #[tauri::command]
@@ -767,9 +975,10 @@ mod tests {
         assert!(script.contains("/bin/mv -f '/tmp/launched.tmp' '/tmp/launched'"));
         assert!(script.contains("/bin/mv -f '/tmp/status.txt.tmp' '/tmp/status.txt'"));
         assert!(script.contains("finish_terminal 130; exit 130"));
-        assert!(script.contains(
-            "if [[ -e '/tmp/cancel' ]]; then\n  finish_terminal 130\n  exit 130\nfi\n/bin/stty -echo"
-        ));
+        let cancel_check = script.find("if [[ -e '/tmp/cancel' ]]").unwrap();
+        let command_start = script.find("command-starting").unwrap();
+        let secret_prompt = script.find("/bin/stty -echo").unwrap();
+        assert!(cancel_check < command_start && command_start < secret_prompt);
         assert!(!script.contains("/usr/bin/tee"));
     }
 
@@ -819,7 +1028,7 @@ mod tests {
         let result = Command::new("/bin/zsh").arg(&script_path).output().unwrap();
         assert_eq!(result.status.code(), Some(130));
         assert!(!command_marker.exists());
-        assert!(launch_ack_path.exists());
+        assert!(!launch_ack_path.exists());
         assert_eq!(fs::read_to_string(status_path).unwrap(), "130\ncancelled\n");
     }
 
@@ -835,6 +1044,7 @@ mod tests {
             status_path: directory.path().join("status"),
             cli_path: PathBuf::from("/missing/anylinuxfs"),
             persistent_mount: false,
+            cancellation_started: false,
         };
         let writer = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(75));
@@ -846,6 +1056,137 @@ mod tests {
             Some(4242)
         );
         writer.join().unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cancellation_terminates_nested_processes() {
+        let directory = tempfile::tempdir().unwrap();
+        let script_path = directory.path().join("run-anylinuxfs.command");
+        fs::write(
+            &script_path,
+            b"#!/bin/sh\ntrap '' TERM\n/bin/sleep 30 & wait\n",
+        )
+        .unwrap();
+        let session = TerminalSession {
+            operation: "list".to_string(),
+            cancel_path: directory.path().join("cancel"),
+            pid_path: directory.path().join("shell.pid"),
+            launch_ack_path: directory.path().join("launched"),
+            status_path: directory.path().join("status"),
+            cli_path: PathBuf::from("/missing/anylinuxfs"),
+            persistent_mount: false,
+            cancellation_started: false,
+        };
+        let mut shell = Command::new("/bin/sh")
+            .arg(&script_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let shell_pid = shell.id();
+
+        let descendants = (0..20)
+            .find_map(|_| {
+                let descendants = child_process_ids(shell_pid);
+                if descendants.is_empty() {
+                    std::thread::sleep(Duration::from_millis(25));
+                    None
+                } else {
+                    Some(descendants)
+                }
+            })
+            .expect("nested process should start");
+
+        assert!(recorded_terminal_shell_matches(&session, shell_pid));
+        terminate_process_tree(&session, shell_pid);
+        let _ = shell.wait();
+        for pid in std::iter::once(shell_pid).chain(descendants) {
+            let state = Command::new("/bin/ps")
+                .args(["-p", &pid.to_string(), "-o", "stat="])
+                .output()
+                .unwrap();
+            let state = String::from_utf8_lossy(&state.stdout);
+            assert!(state.trim().is_empty() || state.trim().starts_with('Z'));
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cancelled_mount_waits_for_device_cleanup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let cleanup_marker = directory.path().join("cleanup-finished");
+        let cli_path = directory.path().join("fake-anylinuxfs");
+        fs::write(
+            &cli_path,
+            format!(
+                "#!/bin/sh\n/bin/sleep 0.1\n/usr/bin/touch {}\n",
+                shell_quote(&cleanup_marker.to_string_lossy())
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli_path, fs::Permissions::from_mode(0o700)).unwrap();
+        let session = TerminalSession {
+            operation: "mount:/dev/disk7".to_string(),
+            cancel_path: directory.path().join("cancel"),
+            pid_path: directory.path().join("missing.pid"),
+            launch_ack_path: directory.path().join("launched"),
+            status_path: directory.path().join("status"),
+            cli_path,
+            persistent_mount: false,
+            cancellation_started: false,
+        };
+        fs::write(&session.launch_ack_path, b"launched\n").unwrap();
+
+        cancel_terminal_session(&session, true);
+        assert!(cleanup_marker.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cancellation_waits_for_command_start_decision() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let cleanup_marker = directory.path().join("cleanup-finished");
+        let cli_path = directory.path().join("fake-anylinuxfs");
+        fs::write(
+            &cli_path,
+            format!(
+                "#!/bin/sh\n/usr/bin/touch {}\n",
+                shell_quote(&cleanup_marker.to_string_lossy())
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli_path, fs::Permissions::from_mode(0o700)).unwrap();
+        let session = TerminalSession {
+            operation: "mount:/dev/disk7".to_string(),
+            cancel_path: directory.path().join("cancel"),
+            pid_path: directory.path().join("missing.pid"),
+            launch_ack_path: directory.path().join("launched"),
+            status_path: directory.path().join("status"),
+            cli_path,
+            persistent_mount: false,
+            cancellation_started: false,
+        };
+        let start_gate_path = directory.path().join("start-gate");
+        fs::create_dir(&start_gate_path).unwrap();
+
+        let cancelling_session = session.clone();
+        let cancellation =
+            std::thread::spawn(move || cancel_terminal_session(&cancelling_session, true));
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(!session.cancel_path.exists());
+
+        fs::write(&session.launch_ack_path, b"command-starting\n").unwrap();
+        fs::remove_dir(start_gate_path).unwrap();
+        cancellation.join().unwrap();
+
+        assert!(session.cancel_path.exists());
+        assert!(cleanup_marker.exists());
     }
 
     #[test]
@@ -923,6 +1264,58 @@ mod tests {
     }
 
     #[test]
+    fn persistent_mount_timeout_does_not_cancel_processes() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = ElevationState::load(directory.path().join("preferences.toml"));
+        let cancel_path = directory.path().join("cancel");
+        let status_path = directory.path().join("status");
+        fs::write(&status_path, b"pending\n").unwrap();
+        let (session_id, _) = state.register_session(
+            "mount:/dev/disk7".to_string(),
+            cancel_path.clone(),
+            directory.path().join("missing.pid"),
+            directory.path().join("launched"),
+            status_path.clone(),
+            PathBuf::from("/missing/anylinuxfs"),
+        );
+        assert!(state.mark_mount_persistent("/dev/disk7"));
+
+        let result = wait_for_terminal_result(
+            &state,
+            session_id,
+            &status_path,
+            &directory.path().join("output"),
+            &cancel_path,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(result.unwrap(), "");
+        assert!(!cancel_path.exists());
+        state.unregister_session(session_id);
+        assert_eq!(state.active_session_count(), 0);
+    }
+
+    #[test]
+    fn timeout_cancellation_cannot_be_overwritten_by_persistence() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = ElevationState::load(directory.path().join("preferences.toml"));
+        state.set_mode(ElevationMode::InteractiveTerminal).unwrap();
+        let (session_id, _) = state.register_session(
+            "mount:/dev/disk7".to_string(),
+            directory.path().join("cancel"),
+            directory.path().join("missing.pid"),
+            directory.path().join("launched"),
+            directory.path().join("status"),
+            PathBuf::from("/missing/anylinuxfs"),
+        );
+
+        assert!(!state.cancel_session_for_timeout(session_id));
+        assert!(!state.mark_mount_persistent("/dev/disk7"));
+        state.unregister_session(session_id);
+        assert!(!state.mark_mount_persistent("/dev/disk7"));
+    }
+
+    #[test]
     fn cancellation_before_terminal_registration_is_not_lost() {
         let directory = tempfile::tempdir().unwrap();
         let state = Arc::new(ElevationState::load(
@@ -933,6 +1326,7 @@ mod tests {
             .expect("operation should begin");
         assert!(state.begin_operation("mount:/dev/disk7").is_err());
         assert_eq!(state.request_mount_cancellation("/dev/disk7"), 1);
+        assert!(!state.mark_mount_persistent("/dev/disk7"));
 
         let cancel_path = directory.path().join("cancel");
         let (_, cancellation_observed) = state.register_session(
@@ -977,7 +1371,7 @@ mod tests {
             directory.path().join("status"),
             PathBuf::from("/missing/anylinuxfs"),
         );
-        state.mark_mount_persistent("/dev/disk7");
+        assert!(state.mark_mount_persistent("/dev/disk7"));
         assert_eq!(state.cancel_all_pending(), 0);
         assert!(!cancel_path.exists());
     }

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -21,7 +21,6 @@ pub enum ElevationMode {
 #[derive(Debug, Clone, Serialize)]
 pub struct ElevationPolicy {
     pub mode: ElevationMode,
-    pub locked: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +65,8 @@ struct TerminalSession {
     operation: String,
     cancel_path: PathBuf,
     pid_path: PathBuf,
+    launch_ack_path: PathBuf,
+    status_path: PathBuf,
     cli_path: PathBuf,
     persistent_mount: bool,
 }
@@ -82,6 +83,13 @@ pub struct ElevationState {
 pub struct ElevationOperationGuard {
     state: Arc<ElevationState>,
     operation: String,
+    mode: ElevationMode,
+}
+
+impl ElevationOperationGuard {
+    pub fn mode(&self) -> ElevationMode {
+        self.mode
+    }
 }
 
 impl Drop for ElevationOperationGuard {
@@ -92,11 +100,7 @@ impl Drop for ElevationOperationGuard {
 
 impl ElevationState {
     pub fn load(config_path: PathBuf) -> Self {
-        let mode = if managed_terminal_elevation_locked() {
-            ElevationMode::InteractiveTerminal
-        } else {
-            read_stored_mode(&config_path).unwrap_or(ElevationMode::Native)
-        };
+        let mode = read_stored_mode(&config_path).unwrap_or(ElevationMode::Native);
 
         Self {
             config_path,
@@ -109,10 +113,7 @@ impl ElevationState {
     }
 
     pub fn policy(&self) -> ElevationPolicy {
-        ElevationPolicy {
-            mode: self.mode(),
-            locked: managed_terminal_elevation_locked(),
-        }
+        ElevationPolicy { mode: self.mode() }
     }
 
     pub fn mode(&self) -> ElevationMode {
@@ -123,8 +124,18 @@ impl ElevationState {
     }
 
     pub fn set_mode(&self, mode: ElevationMode) -> Result<ElevationPolicy, String> {
-        if managed_terminal_elevation_locked() && mode != ElevationMode::InteractiveTerminal {
-            return Err("This build requires interactive Terminal elevation".to_string());
+        // Keep the selected policy stable for the lifetime of every privileged
+        // operation. Holding this lock through persistence closes the window in
+        // which a new operation could snapshot the old mode while it is changing.
+        let active_operations = self
+            .active_operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !active_operations.is_empty() {
+            return Err(
+                "Elevation mode cannot be changed while a privileged operation is active"
+                    .to_string(),
+            );
         }
 
         write_stored_mode(&self.config_path, mode)?;
@@ -132,6 +143,7 @@ impl ElevationState {
             .mode
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = mode;
+        drop(active_operations);
         Ok(self.policy())
     }
 
@@ -140,6 +152,8 @@ impl ElevationState {
         operation: String,
         cancel_path: PathBuf,
         pid_path: PathBuf,
+        launch_ack_path: PathBuf,
+        status_path: PathBuf,
         cli_path: PathBuf,
     ) -> (u64, bool) {
         let id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
@@ -147,6 +161,8 @@ impl ElevationState {
             operation: operation.clone(),
             cancel_path,
             pid_path,
+            launch_ack_path,
+            status_path,
             cli_path,
             persistent_mount: false,
         };
@@ -202,6 +218,7 @@ impl ElevationState {
         if active_operations.contains(&operation) {
             return Err(format!("Operation is already in progress: {}", operation));
         }
+        let mode = self.mode();
         let mut cancellation_requests = self
             .cancellation_requests
             .lock()
@@ -211,6 +228,7 @@ impl ElevationState {
         Ok(ElevationOperationGuard {
             state: self.clone(),
             operation,
+            mode,
         })
     }
 
@@ -308,10 +326,6 @@ impl ElevationState {
     }
 }
 
-fn managed_terminal_elevation_locked() -> bool {
-    cfg!(feature = "managed-terminal-elevation")
-}
-
 fn read_stored_mode(path: &Path) -> Option<ElevationMode> {
     let contents = fs::read_to_string(path).ok()?;
     toml::from_str::<StoredPreferences>(&contents)
@@ -360,11 +374,15 @@ fn terminal_script_content(
     status_path: &Path,
     cancel_path: &Path,
     pid_path: &Path,
+    launch_ack_path: &Path,
     prompts_for_secret: bool,
 ) -> String {
     let prelude = format!(
         r#"#!/bin/zsh
-/usr/bin/printf '%s\n' "$$" > {pid_path}
+/usr/bin/printf '%s\n' "$$" > {pid_temp_path}
+/bin/mv -f {pid_temp_path} {pid_path}
+/usr/bin/printf '%s\n' "launched" > {launch_ack_temp_path}
+/bin/mv -f {launch_ack_temp_path} {launch_ack_path}
 restore_terminal_echo() {{ /bin/stty echo 2>/dev/null }}
 finish_terminal() {{
   command_status="$1"
@@ -375,8 +393,15 @@ finish_terminal() {{
   restore_terminal_echo
 }}
 trap 'finish_terminal 130; exit 130' HUP INT TERM
+if [[ -e {cancel_path} ]]; then
+  finish_terminal 130
+  exit 130
+fi
 "#,
         pid_path = shell_quote(&pid_path.to_string_lossy()),
+        pid_temp_path = shell_quote(&format!("{}.tmp", pid_path.to_string_lossy())),
+        launch_ack_path = shell_quote(&launch_ack_path.to_string_lossy()),
+        launch_ack_temp_path = shell_quote(&format!("{}.tmp", launch_ack_path.to_string_lossy())),
         cancel_path = shell_quote(&cancel_path.to_string_lossy()),
         status_path = shell_quote(&status_path.to_string_lossy()),
         status_temp_path = shell_quote(&format!("{}.tmp", status_path.to_string_lossy())),
@@ -436,6 +461,7 @@ pub fn execute_in_terminal(
     let status_path = work_dir.path().join("status.txt");
     let cancel_path = work_dir.path().join("cancel");
     let pid_path = work_dir.path().join("shell.pid");
+    let launch_ack_path = work_dir.path().join("launched");
 
     let mut command_parts = Vec::with_capacity(args.len() + 2);
     command_parts.push("/usr/bin/sudo".to_string());
@@ -449,6 +475,7 @@ pub fn execute_in_terminal(
         &status_path,
         &cancel_path,
         &pid_path,
+        &launch_ack_path,
         interaction.prompts_for_secret(),
     );
     let mut script = fs::File::create(&script_path).map_err(|e| {
@@ -467,6 +494,8 @@ pub fn execute_in_terminal(
         interaction.operation().to_string(),
         cancel_path.clone(),
         pid_path,
+        launch_ack_path,
+        status_path.clone(),
         cli_path.to_path_buf(),
     );
     if cancellation_requested {
@@ -605,10 +634,18 @@ fn ensure_terminal_session_stopped(state: &ElevationState, id: u64) {
     let Some(session) = session else {
         return;
     };
-    let Ok(pid_text) = fs::read_to_string(&session.pid_path) else {
-        return;
-    };
-    let Ok(pid) = pid_text.trim().parse::<u32>() else {
+    // `open` returns after LaunchServices accepts the request, not necessarily
+    // after Terminal starts the script. Keep the cancel marker alive while we
+    // wait for the script's acknowledgement/PID so a delayed launch cannot run
+    // the privileged command after the user has cancelled it.
+    let Some(pid) = wait_for_terminal_session_pid(&session, Duration::from_secs(5)) else {
+        if session.launch_ack_path.exists() {
+            log::warn!(
+                "Terminal elevation acknowledged launch without publishing a valid shell PID"
+            );
+        } else {
+            log::debug!("Terminal elevation did not launch before cancellation cleanup");
+        }
         return;
     };
     if pid <= 1 {
@@ -632,6 +669,23 @@ fn ensure_terminal_session_stopped(state: &ElevationState, id: u64) {
     let _ = Command::new("/bin/kill")
         .args(["-KILL", &pid.to_string()])
         .status();
+}
+
+fn read_session_pid(path: &Path) -> Option<u32> {
+    fs::read_to_string(path).ok()?.trim().parse::<u32>().ok()
+}
+
+fn wait_for_terminal_session_pid(session: &TerminalSession, timeout: Duration) -> Option<u32> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(pid) = read_session_pid(&session.pid_path) {
+            return Some(pid);
+        }
+        if session.status_path.exists() || Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn process_exists(pid: u32) -> bool {
@@ -703,14 +757,19 @@ mod tests {
             Path::new("/tmp/status.txt"),
             Path::new("/tmp/cancel"),
             Path::new("/tmp/shell.pid"),
+            Path::new("/tmp/launched"),
             true,
         );
         assert!(script.contains("/bin/stty -echo"));
         assert!(script.contains("/usr/bin/script -q /dev/null /usr/bin/sudo"));
         assert!(script.contains("shell.pid"));
         assert!(script.contains("cancel"));
+        assert!(script.contains("/bin/mv -f '/tmp/launched.tmp' '/tmp/launched'"));
         assert!(script.contains("/bin/mv -f '/tmp/status.txt.tmp' '/tmp/status.txt'"));
         assert!(script.contains("finish_terminal 130; exit 130"));
+        assert!(script.contains(
+            "if [[ -e '/tmp/cancel' ]]; then\n  finish_terminal 130\n  exit 130\nfi\n/bin/stty -echo"
+        ));
         assert!(!script.contains("/usr/bin/tee"));
     }
 
@@ -723,10 +782,70 @@ mod tests {
             Path::new("/tmp/status.txt"),
             Path::new("/tmp/cancel"),
             Path::new("/tmp/shell.pid"),
+            Path::new("/tmp/launched"),
             false,
         );
         assert!(script.contains("/usr/bin/tee '/tmp/output.txt'"));
         assert!(!script.contains("/bin/stty -echo"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn preexisting_cancel_marker_prevents_command_execution() {
+        let directory = tempfile::tempdir().unwrap();
+        let command_marker = directory.path().join("command-ran");
+        let output_path = directory.path().join("output.txt");
+        let status_path = directory.path().join("status.txt");
+        let cancel_path = directory.path().join("cancel");
+        let pid_path = directory.path().join("shell.pid");
+        let launch_ack_path = directory.path().join("launched");
+        fs::write(&cancel_path, b"cancelled\n").unwrap();
+
+        let script = terminal_script_content(
+            &format!(
+                "/usr/bin/touch {}",
+                shell_quote(&command_marker.to_string_lossy())
+            ),
+            &output_path,
+            &status_path,
+            &cancel_path,
+            &pid_path,
+            &launch_ack_path,
+            false,
+        );
+        let script_path = directory.path().join("cancelled.command");
+        fs::write(&script_path, script).unwrap();
+
+        let result = Command::new("/bin/zsh").arg(&script_path).output().unwrap();
+        assert_eq!(result.status.code(), Some(130));
+        assert!(!command_marker.exists());
+        assert!(launch_ack_path.exists());
+        assert_eq!(fs::read_to_string(status_path).unwrap(), "130\ncancelled\n");
+    }
+
+    #[test]
+    fn cancellation_cleanup_waits_for_a_delayed_shell_pid() {
+        let directory = tempfile::tempdir().unwrap();
+        let pid_path = directory.path().join("shell.pid");
+        let session = TerminalSession {
+            operation: "list".to_string(),
+            cancel_path: directory.path().join("cancel"),
+            pid_path: pid_path.clone(),
+            launch_ack_path: directory.path().join("launched"),
+            status_path: directory.path().join("status"),
+            cli_path: PathBuf::from("/missing/anylinuxfs"),
+            persistent_mount: false,
+        };
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(75));
+            fs::write(pid_path, b"4242\n").unwrap();
+        });
+
+        assert_eq!(
+            wait_for_terminal_session_pid(&session, Duration::from_secs(1)),
+            Some(4242)
+        );
+        writer.join().unwrap();
     }
 
     #[test]
@@ -735,17 +854,12 @@ mod tests {
         let path = directory.path().join("preferences.toml");
         let state = ElevationState::load(path.clone());
 
-        if managed_terminal_elevation_locked() {
-            assert_eq!(state.mode(), ElevationMode::InteractiveTerminal);
-            assert!(state.set_mode(ElevationMode::Native).is_err());
-        } else {
-            assert_eq!(state.mode(), ElevationMode::Native);
-            state.set_mode(ElevationMode::InteractiveTerminal).unwrap();
-            assert_eq!(
-                ElevationState::load(path).mode(),
-                ElevationMode::InteractiveTerminal
-            );
-        }
+        assert_eq!(state.mode(), ElevationMode::Native);
+        state.set_mode(ElevationMode::InteractiveTerminal).unwrap();
+        assert_eq!(
+            ElevationState::load(path).mode(),
+            ElevationMode::InteractiveTerminal
+        );
     }
 
     #[test]
@@ -763,6 +877,24 @@ mod tests {
     }
 
     #[test]
+    fn elevation_mode_is_stable_while_an_operation_is_active() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = Arc::new(ElevationState::load(
+            directory.path().join("preferences.toml"),
+        ));
+        state.set_mode(ElevationMode::InteractiveTerminal).unwrap();
+
+        let operation = state.begin_operation("list").unwrap();
+        assert_eq!(operation.mode(), ElevationMode::InteractiveTerminal);
+        assert!(state.set_mode(ElevationMode::Native).is_err());
+        assert!(state.begin_operation("list").is_err());
+        drop(operation);
+
+        state.set_mode(ElevationMode::Native).unwrap();
+        assert_eq!(state.mode(), ElevationMode::Native);
+    }
+
+    #[test]
     fn timeout_marks_session_cancelled_and_does_not_leave_it_active() {
         let directory = tempfile::tempdir().unwrap();
         let state = ElevationState::load(directory.path().join("preferences.toml"));
@@ -772,6 +904,8 @@ mod tests {
             "list".to_string(),
             cancel_path.clone(),
             pid_path,
+            directory.path().join("launched"),
+            directory.path().join("status"),
             PathBuf::from("/missing/anylinuxfs"),
         );
         let result = wait_for_terminal_result(
@@ -805,6 +939,8 @@ mod tests {
             "mount:/dev/disk7".to_string(),
             cancel_path.clone(),
             directory.path().join("missing.pid"),
+            directory.path().join("launched"),
+            directory.path().join("status"),
             PathBuf::from("/missing/anylinuxfs"),
         );
         assert!(cancellation_observed);
@@ -837,6 +973,8 @@ mod tests {
             "mount:/dev/disk7".to_string(),
             cancel_path.clone(),
             directory.path().join("missing.pid"),
+            directory.path().join("launched"),
+            directory.path().join("status"),
             PathBuf::from("/missing/anylinuxfs"),
         );
         state.mark_mount_persistent("/dev/disk7");

--- a/src-tauri/src/elevation.rs
+++ b/src-tauri/src/elevation.rs
@@ -1,0 +1,846 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+/// Managed approval and an encryption prompt can both require user interaction.
+pub const INTERACTIVE_ELEVATION_TIMEOUT_SECS: u64 = 600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ElevationMode {
+    Native,
+    InteractiveTerminal,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ElevationPolicy {
+    pub mode: ElevationMode,
+    pub locked: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum TerminalInteraction {
+    CaptureOutput { operation: String },
+    SecretPrompt { operation: String },
+}
+
+impl TerminalInteraction {
+    fn operation(&self) -> &str {
+        match self {
+            Self::CaptureOutput { operation } | Self::SecretPrompt { operation } => operation,
+        }
+    }
+
+    fn prompts_for_secret(&self) -> bool {
+        matches!(self, Self::SecretPrompt { .. })
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum TerminalExecutionError {
+    #[error("ALFS_SILENT_AUTH_EXPIRED")]
+    InteractionRequired,
+    #[error("Interactive Terminal operation was cancelled")]
+    Cancelled,
+    #[error("Interactive Terminal operation timed out")]
+    TimedOut,
+    #[error("Interactive Terminal command failed with status {status}. Review the Terminal tab for details.")]
+    CommandFailed { status: i32, output: String },
+    #[error("{0}")]
+    Launch(String),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredPreferences {
+    mode: ElevationMode,
+}
+
+#[derive(Debug, Clone)]
+struct TerminalSession {
+    operation: String,
+    cancel_path: PathBuf,
+    pid_path: PathBuf,
+    cli_path: PathBuf,
+    persistent_mount: bool,
+}
+
+pub struct ElevationState {
+    config_path: PathBuf,
+    mode: RwLock<ElevationMode>,
+    sessions: Mutex<HashMap<u64, TerminalSession>>,
+    active_operations: Mutex<HashSet<String>>,
+    cancellation_requests: Mutex<HashSet<String>>,
+    next_session_id: AtomicU64,
+}
+
+pub struct ElevationOperationGuard {
+    state: Arc<ElevationState>,
+    operation: String,
+}
+
+impl Drop for ElevationOperationGuard {
+    fn drop(&mut self) {
+        self.state.finish_operation(&self.operation);
+    }
+}
+
+impl ElevationState {
+    pub fn load(config_path: PathBuf) -> Self {
+        let mode = if managed_terminal_elevation_locked() {
+            ElevationMode::InteractiveTerminal
+        } else {
+            read_stored_mode(&config_path).unwrap_or(ElevationMode::Native)
+        };
+
+        Self {
+            config_path,
+            mode: RwLock::new(mode),
+            sessions: Mutex::new(HashMap::new()),
+            active_operations: Mutex::new(HashSet::new()),
+            cancellation_requests: Mutex::new(HashSet::new()),
+            next_session_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn policy(&self) -> ElevationPolicy {
+        ElevationPolicy {
+            mode: self.mode(),
+            locked: managed_terminal_elevation_locked(),
+        }
+    }
+
+    pub fn mode(&self) -> ElevationMode {
+        *self
+            .mode
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    pub fn set_mode(&self, mode: ElevationMode) -> Result<ElevationPolicy, String> {
+        if managed_terminal_elevation_locked() && mode != ElevationMode::InteractiveTerminal {
+            return Err("This build requires interactive Terminal elevation".to_string());
+        }
+
+        write_stored_mode(&self.config_path, mode)?;
+        *self
+            .mode
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = mode;
+        Ok(self.policy())
+    }
+
+    fn register_session(
+        &self,
+        operation: String,
+        cancel_path: PathBuf,
+        pid_path: PathBuf,
+        cli_path: PathBuf,
+    ) -> (u64, bool) {
+        let id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
+        let session = TerminalSession {
+            operation: operation.clone(),
+            cancel_path,
+            pid_path,
+            cli_path,
+            persistent_mount: false,
+        };
+        self.sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(id, session.clone());
+
+        // A UI cancellation can arrive after mount_disk starts but just before
+        // Terminal registration. Consume that request here so no command is
+        // launched after the user has cancelled it.
+        let cancellation_requested = self
+            .cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&operation);
+        if cancellation_requested {
+            cancel_terminal_session(&session);
+        }
+        (id, cancellation_requested)
+    }
+
+    fn unregister_session(&self, id: u64) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&id);
+    }
+
+    pub fn mark_mount_persistent(&self, device: &str) {
+        let operation = format!("mount:{}", device);
+        for session in self
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values_mut()
+        {
+            if session.operation == operation {
+                session.persistent_mount = true;
+            }
+        }
+    }
+
+    pub fn begin_operation(
+        self: &Arc<Self>,
+        operation: impl Into<String>,
+    ) -> Result<ElevationOperationGuard, String> {
+        let operation = operation.into();
+        let mut active_operations = self
+            .active_operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if active_operations.contains(&operation) {
+            return Err(format!("Operation is already in progress: {}", operation));
+        }
+        let mut cancellation_requests = self
+            .cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cancellation_requests.remove(&operation);
+        active_operations.insert(operation.clone());
+        Ok(ElevationOperationGuard {
+            state: self.clone(),
+            operation,
+        })
+    }
+
+    fn finish_operation(&self, operation: &str) {
+        let mut active_operations = self
+            .active_operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut cancellation_requests = self
+            .cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        active_operations.remove(operation);
+        cancellation_requests.remove(operation);
+    }
+
+    /// Request user-initiated cancellation. The request is retained while the
+    /// operation is active so it survives the short pre-registration window.
+    pub fn request_mount_cancellation(&self, device: &str) -> usize {
+        let operation = format!("mount:{}", device);
+        let active_operations = self
+            .active_operations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !active_operations.contains(&operation) {
+            return 0;
+        }
+
+        self.cancellation_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(operation.clone());
+        drop(active_operations);
+        let cancelled = self.cancel_matching(Some(&operation), false);
+        cancelled.max(1)
+    }
+
+    /// Cancel only sessions that already exist. Cleanup timeouts use this so
+    /// they cannot cause an unrelated future retry to be cancelled.
+    pub fn cancel_active_mount(&self, device: &str) -> usize {
+        self.cancel_matching(Some(&format!("mount:{}", device)), false)
+    }
+
+    pub fn cancel_pending_operation(&self, operation: &str) -> usize {
+        self.cancel_matching(Some(operation), false)
+    }
+
+    pub fn cancel_all_pending(&self) -> usize {
+        self.cancel_matching(None, false)
+    }
+
+    fn cancel_session(&self, id: u64) -> bool {
+        let session = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&id)
+            .cloned();
+
+        if let Some(session) = session {
+            cancel_terminal_session(&session);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn cancel_matching(&self, operation: Option<&str>, include_persistent: bool) -> usize {
+        let sessions: Vec<TerminalSession> = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .filter(|session| {
+                (include_persistent || !session.persistent_mount)
+                    && operation
+                        .map(|value| value == session.operation.as_str())
+                        .unwrap_or(true)
+            })
+            .cloned()
+            .collect();
+
+        for session in &sessions {
+            cancel_terminal_session(session);
+        }
+        sessions.len()
+    }
+
+    #[cfg(test)]
+    fn active_session_count(&self) -> usize {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+}
+
+fn managed_terminal_elevation_locked() -> bool {
+    cfg!(feature = "managed-terminal-elevation")
+}
+
+fn read_stored_mode(path: &Path) -> Option<ElevationMode> {
+    let contents = fs::read_to_string(path).ok()?;
+    toml::from_str::<StoredPreferences>(&contents)
+        .ok()
+        .map(|preferences| preferences.mode)
+}
+
+fn write_stored_mode(path: &Path, mode: ElevationMode) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Elevation preference path has no parent directory".to_string())?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create preference directory: {}", e))?;
+
+    let contents = toml::to_string(&StoredPreferences { mode })
+        .map_err(|e| format!("Failed to encode elevation preference: {}", e))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| format!("Failed to create temporary preference file: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temp.as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("Failed to secure preference file: {}", e))?;
+    }
+
+    temp.write_all(contents.as_bytes())
+        .map_err(|e| format!("Failed to write elevation preference: {}", e))?;
+    temp.as_file_mut()
+        .sync_all()
+        .map_err(|e| format!("Failed to flush elevation preference: {}", e))?;
+    temp.persist(path)
+        .map_err(|e| format!("Failed to save elevation preference: {}", e.error))?;
+    Ok(())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(target_os = "macos")]
+fn terminal_script_content(
+    command_line: &str,
+    output_path: &Path,
+    status_path: &Path,
+    cancel_path: &Path,
+    pid_path: &Path,
+    prompts_for_secret: bool,
+) -> String {
+    let prelude = format!(
+        r#"#!/bin/zsh
+/usr/bin/printf '%s\n' "$$" > {pid_path}
+restore_terminal_echo() {{ /bin/stty echo 2>/dev/null }}
+finish_terminal() {{
+  command_status="$1"
+  completion="finished"
+  [[ -e {cancel_path} ]] && completion="cancelled"
+  /usr/bin/printf '%s\n%s\n' "$command_status" "$completion" > {status_temp_path}
+  /bin/mv -f {status_temp_path} {status_path}
+  restore_terminal_echo
+}}
+trap 'finish_terminal 130; exit 130' HUP INT TERM
+"#,
+        pid_path = shell_quote(&pid_path.to_string_lossy()),
+        cancel_path = shell_quote(&cancel_path.to_string_lossy()),
+        status_path = shell_quote(&status_path.to_string_lossy()),
+        status_temp_path = shell_quote(&format!("{}.tmp", status_path.to_string_lossy())),
+    );
+
+    let command = if prompts_for_secret {
+        format!(
+            "/bin/stty -echo\n/usr/bin/script -q /dev/null {}\ncommand_status=$?\n",
+            command_line
+        )
+    } else {
+        format!(
+            "{} 2>&1 | /usr/bin/tee {}\ncommand_status=${{pipestatus[1]}}\n",
+            command_line,
+            shell_quote(&output_path.to_string_lossy())
+        )
+    };
+
+    format!(
+        "{}{}finish_terminal \"$command_status\"\ntrap - HUP INT TERM\n/usr/bin/printf '\\nanylinuxfs finished with status %s. This Terminal tab can be closed.\\n' \"$command_status\"\nexit \"$command_status\"\n",
+        prelude, command
+    )
+}
+
+#[cfg(target_os = "macos")]
+pub fn execute_in_terminal(
+    state: &ElevationState,
+    cli_path: &Path,
+    args: &[&str],
+    silent: bool,
+    interaction: TerminalInteraction,
+) -> Result<String, TerminalExecutionError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if silent {
+        return Err(TerminalExecutionError::InteractionRequired);
+    }
+
+    let work_dir = tempfile::Builder::new()
+        .prefix("anylinuxfs-terminal-")
+        .tempdir()
+        .map_err(|e| {
+            TerminalExecutionError::Launch(format!(
+                "Failed to create Terminal handoff directory: {}",
+                e
+            ))
+        })?;
+    fs::set_permissions(work_dir.path(), fs::Permissions::from_mode(0o700)).map_err(|e| {
+        TerminalExecutionError::Launch(format!(
+            "Failed to secure Terminal handoff directory: {}",
+            e
+        ))
+    })?;
+
+    let script_path = work_dir.path().join("run-anylinuxfs.command");
+    let output_path = work_dir.path().join("output.txt");
+    let status_path = work_dir.path().join("status.txt");
+    let cancel_path = work_dir.path().join("cancel");
+    let pid_path = work_dir.path().join("shell.pid");
+
+    let mut command_parts = Vec::with_capacity(args.len() + 2);
+    command_parts.push("/usr/bin/sudo".to_string());
+    command_parts.push(shell_quote(&cli_path.to_string_lossy()));
+    command_parts.extend(args.iter().map(|arg| shell_quote(arg)));
+    let command_line = command_parts.join(" ");
+
+    let script_content = terminal_script_content(
+        &command_line,
+        &output_path,
+        &status_path,
+        &cancel_path,
+        &pid_path,
+        interaction.prompts_for_secret(),
+    );
+    let mut script = fs::File::create(&script_path).map_err(|e| {
+        TerminalExecutionError::Launch(format!("Failed to create Terminal command file: {}", e))
+    })?;
+    script.write_all(script_content.as_bytes()).map_err(|e| {
+        TerminalExecutionError::Launch(format!("Failed to write Terminal command file: {}", e))
+    })?;
+    script
+        .set_permissions(fs::Permissions::from_mode(0o700))
+        .map_err(|e| {
+            TerminalExecutionError::Launch(format!("Failed to secure Terminal command file: {}", e))
+        })?;
+
+    let (session_id, cancellation_requested) = state.register_session(
+        interaction.operation().to_string(),
+        cancel_path.clone(),
+        pid_path,
+        cli_path.to_path_buf(),
+    );
+    if cancellation_requested {
+        state.unregister_session(session_id);
+        return Err(TerminalExecutionError::Cancelled);
+    }
+
+    let launched = match Command::new("/usr/bin/open")
+        .args(["-a", "Terminal"])
+        .arg(&script_path)
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) => {
+            state.unregister_session(session_id);
+            return Err(TerminalExecutionError::Launch(format!(
+                "Failed to open Terminal: {}",
+                error
+            )));
+        }
+    };
+    if !launched.status.success() {
+        state.unregister_session(session_id);
+        return Err(TerminalExecutionError::Launch(format!(
+            "Failed to open Terminal: {}",
+            String::from_utf8_lossy(&launched.stderr).trim()
+        )));
+    }
+
+    log::debug!("sudo: waiting for interactive elevation in Terminal");
+    let result = wait_for_terminal_result(
+        state,
+        session_id,
+        &status_path,
+        &output_path,
+        &cancel_path,
+        Duration::from_secs(INTERACTIVE_ELEVATION_TIMEOUT_SECS),
+    );
+    if matches!(
+        result,
+        Err(TerminalExecutionError::Cancelled | TerminalExecutionError::TimedOut)
+    ) {
+        ensure_terminal_session_stopped(state, session_id);
+    }
+    state.unregister_session(session_id);
+    result
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn execute_in_terminal(
+    _state: &ElevationState,
+    _cli_path: &Path,
+    _args: &[&str],
+    _silent: bool,
+    _interaction: TerminalInteraction,
+) -> Result<String, TerminalExecutionError> {
+    Err(TerminalExecutionError::Launch(
+        "Interactive Terminal elevation is only available on macOS".to_string(),
+    ))
+}
+
+fn wait_for_terminal_result(
+    state: &ElevationState,
+    session_id: u64,
+    status_path: &Path,
+    output_path: &Path,
+    cancel_path: &Path,
+    timeout: Duration,
+) -> Result<String, TerminalExecutionError> {
+    let start = Instant::now();
+    loop {
+        if let Ok(status_text) = fs::read_to_string(status_path) {
+            let mut lines = status_text.lines();
+            if let Some(status) = lines
+                .next()
+                .and_then(|value| value.trim().parse::<i32>().ok())
+            {
+                let completion = lines.next().unwrap_or("finished");
+                let output = fs::read_to_string(output_path).unwrap_or_default();
+                if completion == "cancelled" || cancel_path.exists() {
+                    return Err(TerminalExecutionError::Cancelled);
+                }
+                if status == 0 {
+                    return Ok(output);
+                }
+                return Err(TerminalExecutionError::CommandFailed { status, output });
+            }
+        }
+
+        if cancel_path.exists() {
+            return Err(TerminalExecutionError::Cancelled);
+        }
+        if start.elapsed() > timeout {
+            state.cancel_session(session_id);
+            return Err(TerminalExecutionError::TimedOut);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn cancel_terminal_session(session: &TerminalSession) {
+    if let Err(error) = fs::write(&session.cancel_path, b"cancelled\n") {
+        log::warn!("Failed to mark Terminal session cancelled: {}", error);
+    }
+
+    if let Ok(pid_text) = fs::read_to_string(&session.pid_path) {
+        if let Ok(pid) = pid_text.trim().parse::<u32>() {
+            if pid > 1 {
+                let _ = Command::new("/usr/bin/pkill")
+                    .args(["-TERM", "-P", &pid.to_string()])
+                    .status();
+                let _ = Command::new("/bin/kill")
+                    .args(["-TERM", &pid.to_string()])
+                    .status();
+            }
+        }
+    }
+
+    if let Some(device) = session.operation.strip_prefix("mount:") {
+        let _ = Command::new(&session.cli_path)
+            .args(["stop", device])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn();
+    }
+}
+
+fn ensure_terminal_session_stopped(state: &ElevationState, id: u64) {
+    let session = state
+        .sessions
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&id)
+        .cloned();
+    let Some(session) = session else {
+        return;
+    };
+    let Ok(pid_text) = fs::read_to_string(&session.pid_path) else {
+        return;
+    };
+    let Ok(pid) = pid_text.trim().parse::<u32>() else {
+        return;
+    };
+    if pid <= 1 {
+        return;
+    }
+
+    for _ in 0..20 {
+        if !process_exists(pid) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    log::warn!(
+        "Terminal elevation shell {} did not stop after cancellation; forcing termination",
+        pid
+    );
+    let _ = Command::new("/usr/bin/pkill")
+        .args(["-KILL", "-P", &pid.to_string()])
+        .status();
+    let _ = Command::new("/bin/kill")
+        .args(["-KILL", &pid.to_string()])
+        .status();
+}
+
+fn process_exists(pid: u32) -> bool {
+    Command::new("/bin/kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn get_elevation_policy(state: tauri::State<'_, Arc<ElevationState>>) -> ElevationPolicy {
+    state.policy()
+}
+
+#[tauri::command]
+pub fn set_elevation_mode(
+    state: tauri::State<'_, Arc<ElevationState>>,
+    mode: ElevationMode,
+) -> Result<ElevationPolicy, String> {
+    state.set_mode(mode)
+}
+
+#[tauri::command]
+pub fn cancel_elevation_operation(
+    state: tauri::State<'_, Arc<ElevationState>>,
+    device: String,
+) -> Result<usize, String> {
+    if !valid_device_identifier(&device) {
+        return Err("Invalid device path".to_string());
+    }
+    Ok(state.request_mount_cancellation(&device))
+}
+
+fn valid_device_identifier(device: &str) -> bool {
+    if let Some(suffix) = device.strip_prefix("/dev/") {
+        return !suffix.is_empty()
+            && suffix.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            });
+    }
+    if device.starts_with("raid:") || device.starts_with("lvm:") {
+        return device.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, ':' | '-' | '_')
+        });
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_prevents_expansion_and_handles_single_quotes() {
+        assert_eq!(shell_quote("/dev/disk7"), "'/dev/disk7'");
+        assert_eq!(shell_quote("$(touch /tmp/nope)"), "'$(touch /tmp/nope)'");
+        assert_eq!(shell_quote("a'b"), "'a'\"'\"'b'");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn secret_prompt_uses_unrecorded_pty_and_echo_protection() {
+        let script = terminal_script_content(
+            "/usr/bin/sudo '/opt/homebrew/bin/anylinuxfs' 'mount' '/dev/disk7'",
+            Path::new("/tmp/output.txt"),
+            Path::new("/tmp/status.txt"),
+            Path::new("/tmp/cancel"),
+            Path::new("/tmp/shell.pid"),
+            true,
+        );
+        assert!(script.contains("/bin/stty -echo"));
+        assert!(script.contains("/usr/bin/script -q /dev/null /usr/bin/sudo"));
+        assert!(script.contains("shell.pid"));
+        assert!(script.contains("cancel"));
+        assert!(script.contains("/bin/mv -f '/tmp/status.txt.tmp' '/tmp/status.txt'"));
+        assert!(script.contains("finish_terminal 130; exit 130"));
+        assert!(!script.contains("/usr/bin/tee"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn non_secret_command_captures_parseable_output() {
+        let script = terminal_script_content(
+            "/usr/bin/sudo '/opt/homebrew/bin/anylinuxfs' 'list'",
+            Path::new("/tmp/output.txt"),
+            Path::new("/tmp/status.txt"),
+            Path::new("/tmp/cancel"),
+            Path::new("/tmp/shell.pid"),
+            false,
+        );
+        assert!(script.contains("/usr/bin/tee '/tmp/output.txt'"));
+        assert!(!script.contains("/bin/stty -echo"));
+    }
+
+    #[test]
+    fn preference_round_trip_uses_rust_owned_storage() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.toml");
+        let state = ElevationState::load(path.clone());
+
+        if managed_terminal_elevation_locked() {
+            assert_eq!(state.mode(), ElevationMode::InteractiveTerminal);
+            assert!(state.set_mode(ElevationMode::Native).is_err());
+        } else {
+            assert_eq!(state.mode(), ElevationMode::Native);
+            state.set_mode(ElevationMode::InteractiveTerminal).unwrap();
+            assert_eq!(
+                ElevationState::load(path).mode(),
+                ElevationMode::InteractiveTerminal
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preference_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.toml");
+        let state = ElevationState::load(path.clone());
+        state.set_mode(state.mode()).unwrap();
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn timeout_marks_session_cancelled_and_does_not_leave_it_active() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = ElevationState::load(directory.path().join("preferences.toml"));
+        let cancel_path = directory.path().join("cancel");
+        let pid_path = directory.path().join("missing.pid");
+        let (session_id, _) = state.register_session(
+            "list".to_string(),
+            cancel_path.clone(),
+            pid_path,
+            PathBuf::from("/missing/anylinuxfs"),
+        );
+        let result = wait_for_terminal_result(
+            &state,
+            session_id,
+            &directory.path().join("status"),
+            &directory.path().join("output"),
+            &cancel_path,
+            Duration::from_millis(1),
+        );
+        assert!(matches!(result, Err(TerminalExecutionError::TimedOut)));
+        assert!(cancel_path.exists());
+        state.unregister_session(session_id);
+        assert_eq!(state.active_session_count(), 0);
+    }
+
+    #[test]
+    fn cancellation_before_terminal_registration_is_not_lost() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = Arc::new(ElevationState::load(
+            directory.path().join("preferences.toml"),
+        ));
+        let operation_guard = state
+            .begin_operation("mount:/dev/disk7")
+            .expect("operation should begin");
+        assert!(state.begin_operation("mount:/dev/disk7").is_err());
+        assert_eq!(state.request_mount_cancellation("/dev/disk7"), 1);
+
+        let cancel_path = directory.path().join("cancel");
+        let (_, cancellation_observed) = state.register_session(
+            "mount:/dev/disk7".to_string(),
+            cancel_path.clone(),
+            directory.path().join("missing.pid"),
+            PathBuf::from("/missing/anylinuxfs"),
+        );
+        assert!(cancellation_observed);
+        assert!(cancel_path.exists());
+
+        drop(operation_guard);
+        assert_eq!(state.request_mount_cancellation("/dev/disk7"), 0);
+    }
+
+    #[test]
+    fn cancellation_device_validation_matches_supported_identifiers() {
+        for valid in ["/dev/disk7", "/dev/disk7s1", "raid:md0", "lvm:vg_data"] {
+            assert!(valid_device_identifier(valid), "expected valid: {}", valid);
+        }
+        for invalid in ["disk7", "/dev/../disk7", "raid:md0;reboot", ""] {
+            assert!(
+                !valid_device_identifier(invalid),
+                "expected invalid: {}",
+                invalid
+            );
+        }
+    }
+
+    #[test]
+    fn persistent_mounts_are_not_cancelled_during_app_shutdown() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = ElevationState::load(directory.path().join("preferences.toml"));
+        let cancel_path = directory.path().join("cancel");
+        state.register_session(
+            "mount:/dev/disk7".to_string(),
+            cancel_path.clone(),
+            directory.path().join("missing.pid"),
+            PathBuf::from("/missing/anylinuxfs"),
+        );
+        state.mark_mount_persistent("/dev/disk7");
+        assert_eq!(state.cancel_all_pending(), 0);
+        assert!(!cancel_path.exists());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod cli;
 mod commands;
+mod elevation;
 mod error;
 mod paths;
 
@@ -13,8 +14,19 @@ use tauri::tray::TrayIconBuilder;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, AboutMetadataBuilder, SubmenuBuilder};
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use elevation::{
+    cancel_elevation_operation, get_elevation_policy, set_elevation_mode, ElevationState,
+};
 
 struct UnmountMenuItem(tauri::menu::MenuItem<tauri::Wry>);
+
+fn cancel_pending_elevation(app: &tauri::AppHandle) {
+    let state = app.state::<Arc<ElevationState>>();
+    let cancelled = state.cancel_all_pending();
+    if cancelled > 0 {
+        log::info!("Requested cleanup for {} pending elevation operation(s)", cancelled);
+    }
+}
 
 #[cfg(target_os = "macos")]
 fn set_dock_visible(visible: bool) {
@@ -63,10 +75,12 @@ fn confirm_quit(app: &tauri::AppHandle) {
                 .buttons(MessageDialogButtons::OkCancelCustom("Quit".into(), "Cancel".into()))
                 .show(move |confirmed| {
                     if confirmed {
+                        cancel_pending_elevation(&app_clone);
                         app_clone.exit(0);
                     }
                 });
         } else {
+            cancel_pending_elevation(&app);
             app.exit(0);
         }
     });
@@ -96,6 +110,9 @@ pub fn run() {
         .manage(Arc::new(WatcherState::default()))
         .manage(Arc::new(Mutex::new(PtyState::default())))
         .setup(|app| {
+            let elevation_config = app.path().app_config_dir()?.join("preferences.toml");
+            app.manage(Arc::new(ElevationState::load(elevation_config)));
+
             let show_item = MenuItemBuilder::with_id("show", "Show").build(app)?;
             let unmount_item = MenuItemBuilder::with_id("unmount", "Unmount")
                 .enabled(false)
@@ -205,6 +222,7 @@ pub fn run() {
                 }
                 tauri::WindowEvent::Destroyed => {
                     let app = window.app_handle();
+                    cancel_pending_elevation(app);
                     // Stop watchers
                     let watcher_state = app.state::<Arc<WatcherState>>();
                     watcher_state.shutdown();
@@ -248,6 +266,9 @@ pub fn run() {
             update_custom_action,
             delete_custom_action,
             set_tray_unmount_enabled,
+            get_elevation_policy,
+            set_elevation_mode,
+            cancel_elevation_operation,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/DiskCard.svelte
+++ b/src/components/DiskCard.svelte
@@ -165,6 +165,8 @@
 	}
 
 	async function handleMount() {
+		if ($elevation.loading || $elevation.saving) return;
+
 		// Split ro out of extraOptions for the backend API
 		const parts = optionParts();
 		const ro = parts.includes('ro');
@@ -230,7 +232,7 @@
 						type="checkbox"
 						checked={readOnly()}
 						onchange={toggleReadOnly}
-						disabled={mounting || alreadyMounted}
+						disabled={mounting || alreadyMounted || $elevation.loading || $elevation.saving}
 					/>
 					<span>RO</span>
 				</label>
@@ -238,7 +240,7 @@
 					<button
 						class="mount-btn"
 						onclick={handleMount}
-						disabled={mounting || alreadyMounted}
+						disabled={mounting || alreadyMounted || $elevation.loading || $elevation.saving}
 						title={alreadyMounted ? 'Already mounted' : 'Mount this partition'}
 					>
 						{#if mounting}
@@ -252,7 +254,7 @@
 						class="options-toggle-btn"
 						class:active={showOptions}
 						onclick={() => (showOptions = !showOptions)}
-						disabled={mounting || alreadyMounted}
+						disabled={mounting || alreadyMounted || $elevation.loading || $elevation.saving}
 						title="Mount options"
 					>+</button>
 				</div>

--- a/src/components/DiskCard.svelte
+++ b/src/components/DiskCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Partition } from '$lib/types';
 	import { disks } from '$lib/stores/disks';
+	import { elevation } from '$lib/stores/elevation';
 	import { status, mountedDevices } from '$lib/stores/status';
 
 	interface Props {
@@ -173,13 +174,13 @@
 		saveOptions(extraOptions);
 		saveIgnorePerms(ignorePermissions);
 
-		if (partition.encrypted) {
+		if (partition.encrypted && $elevation.policy.mode !== 'interactive_terminal') {
 			onRequestPassphrase(partition.device, ro, opts, ignorePermissions);
 		} else {
 			const result = await disks.mount(partition.device, undefined, ro, opts, ignorePermissions);
 			if (result === 'encryption_required') {
 				onRequestPassphrase(partition.device, ro, opts, ignorePermissions);
-			} else {
+			} else if (result === 'success') {
 				status.refresh();
 			}
 		}
@@ -242,7 +243,7 @@
 					>
 						{#if mounting}
 							<span class="spinner"></span>
-							Mounting...
+							{$elevation.policy.mode === 'interactive_terminal' ? 'Waiting in Terminal…' : 'Mounting…'}
 						{:else}
 							Mount
 						{/if}

--- a/src/components/MountStatus.svelte
+++ b/src/components/MountStatus.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { status, isMounted } from '$lib/stores/status';
 	import { disks } from '$lib/stores/disks';
-	import { elevation } from '$lib/stores/elevation';
 	import { forceCleanup, setTrayUnmountEnabled } from '$lib/api';
 	import { Timeouts } from '$lib/constants';
 	import { logAction, logError } from '$lib/logger';
@@ -91,7 +90,7 @@
 					<span class="detail-item">{device}</span>
 				</div>
 			</div>
-			{#if $elevation.policy.mode === 'interactive_terminal'}
+			{#if $disks.cancellableMounts.has(device)}
 				<button
 					class="unmount-btn"
 					onclick={() => handleCancelMount(device)}

--- a/src/components/MountStatus.svelte
+++ b/src/components/MountStatus.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { status, isMounted } from '$lib/stores/status';
 	import { disks } from '$lib/stores/disks';
+	import { elevation } from '$lib/stores/elevation';
 	import { forceCleanup, setTrayUnmountEnabled } from '$lib/api';
 	import { Timeouts } from '$lib/constants';
 	import { logAction, logError } from '$lib/logger';
@@ -35,6 +36,10 @@
 		}
 		cleaning = false;
 		status.refresh();
+	}
+
+	async function handleCancelMount(device: string) {
+		await disks.cancelMount(device);
 	}
 </script>
 
@@ -81,11 +86,20 @@
 				<span class="sr-only">Loading</span>
 			</div>
 			<div class="status-info">
-				<div class="status-label">Mounting...</div>
+				<div class="status-label">{$disks.mountingMessages.get(device) || 'Mounting…'}</div>
 				<div class="status-details">
 					<span class="detail-item">{device}</span>
 				</div>
 			</div>
+			{#if $elevation.policy.mode === 'interactive_terminal'}
+				<button
+					class="unmount-btn"
+					onclick={() => handleCancelMount(device)}
+					disabled={$disks.mountingMessages.get(device)?.startsWith('Cancelling')}
+				>
+					{$disks.mountingMessages.get(device)?.startsWith('Cancelling') ? 'Cancelling…' : 'Cancel'}
+				</button>
+			{/if}
 		</div>
 	{/each}
 {/if}

--- a/src/components/PreferencesPanel.svelte
+++ b/src/components/PreferencesPanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
 	import { onMount } from 'svelte';
+	import { elevation } from '$lib/stores/elevation';
+	import type { ElevationMode } from '$lib/types';
 
 	let autoLaunch = $state(false);
 	let autoLaunchLoading = $state(false);
@@ -8,6 +10,11 @@
 	onMount(async () => {
 		autoLaunch = await isEnabled();
 	});
+
+	async function changeElevationMode(e: Event) {
+		const mode = (e.target as HTMLSelectElement).value as ElevationMode;
+		await elevation.setMode(mode);
+	}
 
 	async function toggleAutoLaunch() {
 		autoLaunchLoading = true;
@@ -29,6 +36,39 @@
 <div class="preferences-panel">
 	<div class="header">
 		<h2>Preferences</h2>
+	</div>
+
+	<div class="setting-group">
+		<h3>Administrator authentication</h3>
+		<p class="description">Choose how privileged disk commands request approval.</p>
+
+		<div class="setting">
+			<label for="elevation-mode">Elevation method</label>
+			<select
+				id="elevation-mode"
+				value={$elevation.policy.mode}
+				onchange={changeElevationMode}
+				disabled={$elevation.policy.locked || $elevation.loading || $elevation.saving}
+			>
+				<option value="native">Native sudo (password or Touch ID)</option>
+				<option value="interactive_terminal">Interactive Terminal (managed Macs)</option>
+			</select>
+			{#if $elevation.error}
+				<span class="hint">{$elevation.error}</span>
+			{/if}
+			{#if $elevation.policy.mode === 'interactive_terminal'}
+				<p class="guide-text">
+					Admin scans and mounts open a Terminal tab so interactive privilege-management software can show its approval workflow.
+					For encrypted disks, enter the LUKS passphrase in Terminal when <code>anylinuxfs</code> asks for it.
+				</p>
+				{#if $elevation.policy.locked}
+					<span class="hint">Interactive Terminal elevation is enforced by this managed build.</span>
+				{/if}
+				<span class="hint">Automatic disk changes do not open Terminal; click Refresh while Admin mode is enabled.</span>
+			{:else}
+				<span class="hint">Best for native macOS administrator accounts.</span>
+			{/if}
+		</div>
 	</div>
 
 	<div class="setting-group">

--- a/src/components/PreferencesPanel.svelte
+++ b/src/components/PreferencesPanel.svelte
@@ -2,6 +2,7 @@
 	import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
 	import { onMount } from 'svelte';
 	import { elevation } from '$lib/stores/elevation';
+	import { disks } from '$lib/stores/disks';
 	import type { ElevationMode } from '$lib/types';
 
 	let autoLaunch = $state(false);
@@ -48,7 +49,7 @@
 				id="elevation-mode"
 				value={$elevation.policy.mode}
 				onchange={changeElevationMode}
-				disabled={$elevation.policy.locked || $elevation.loading || $elevation.saving}
+				disabled={$elevation.loading || $elevation.saving || $disks.loading || $disks.mountingDevices.size > 0}
 			>
 				<option value="native">Native sudo (password or Touch ID)</option>
 				<option value="interactive_terminal">Interactive Terminal (managed Macs)</option>
@@ -61,9 +62,6 @@
 					Admin scans and mounts open a Terminal tab so interactive privilege-management software can show its approval workflow.
 					For encrypted disks, enter the LUKS passphrase in Terminal when <code>anylinuxfs</code> asks for it.
 				</p>
-				{#if $elevation.policy.locked}
-					<span class="hint">Interactive Terminal elevation is enforced by this managed build.</span>
-				{/if}
 				<span class="hint">Automatic disk changes do not open Terminal; click Refresh while Admin mode is enabled.</span>
 			{:else}
 				<span class="hint">Best for native macOS administrator accounts.</span>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { DiskListResult, MountInfo, AppConfig, CliStatus } from './types';
+import type {
+	DiskListResult,
+	MountInfo,
+	AppConfig,
+	CliStatus,
+	ElevationMode,
+	ElevationPolicy,
+	MountCommandResult
+} from './types';
 
 export async function checkCli(): Promise<CliStatus> {
 	return await invoke<CliStatus>('check_cli');
@@ -9,8 +17,20 @@ export async function listDisks(useSudo: boolean = false, silent: boolean = fals
 	return await invoke<DiskListResult>('list_disks', { useSudo, silent });
 }
 
-export async function mountDisk(device: string, passphrase?: string, readOnly?: boolean, extraOptions?: string, ignorePermissions?: boolean): Promise<string> {
-	return await invoke<string>('mount_disk', { device, passphrase: passphrase || null, readOnly: readOnly || false, extraOptions: extraOptions || null, ignorePermissions: ignorePermissions || false });
+export async function mountDisk(device: string, passphrase?: string, readOnly?: boolean, extraOptions?: string, ignorePermissions?: boolean): Promise<MountCommandResult> {
+	return await invoke<MountCommandResult>('mount_disk', { device, passphrase: passphrase || null, readOnly: readOnly || false, extraOptions: extraOptions || null, ignorePermissions: ignorePermissions || false });
+}
+
+export async function getElevationPolicy(): Promise<ElevationPolicy> {
+	return await invoke<ElevationPolicy>('get_elevation_policy');
+}
+
+export async function setElevationMode(mode: ElevationMode): Promise<ElevationPolicy> {
+	return await invoke<ElevationPolicy>('set_elevation_mode', { mode });
+}
+
+export async function cancelElevationOperation(device: string): Promise<number> {
+	return await invoke<number>('cancel_elevation_operation', { device });
 }
 
 export async function unmountDisk(device?: string): Promise<string> {

--- a/src/lib/stores/disks.ts
+++ b/src/lib/stores/disks.ts
@@ -1,15 +1,17 @@
 import { writable, derived, get } from 'svelte/store';
 import type { Disk, DiskListResult } from '../types';
-import { listDisks, mountDisk, unmountDisk } from '../api';
+import { cancelElevationOperation, listDisks, mountDisk, unmountDisk } from '../api';
 import { Timeouts, validateDevicePath } from '../constants';
 import { logAction, logError, notifyIfHidden } from '../logger';
 import { parseError } from '../errors';
+import { elevation } from './elevation';
 
 interface DisksState {
 	disks: Disk[];
 	loading: boolean;
 	error: string | null;
 	mountingDevices: Set<string>;
+	mountingMessages: Map<string, string>;
 	adminMode: boolean;
 	hasSupportedPartitions: boolean;
 	recentUnmount: boolean;
@@ -24,6 +26,7 @@ function createDisksStore() {
 		loading: false,
 		error: null,
 		mountingDevices: new Set(),
+		mountingMessages: new Map(),
 		adminMode: false,
 		hasSupportedPartitions: true,
 		recentUnmount: false
@@ -47,6 +50,12 @@ function createDisksStore() {
 			} catch (e) {
 				const rawError = String(e);
 				if (silent && rawError.includes('ALFS_SILENT_AUTH_EXPIRED')) {
+					if (get(elevation).policy.mode === 'interactive_terminal') {
+						// Managed elevation requires visible interaction. Keep the
+						// current list until the user explicitly clicks Refresh.
+						update((s) => ({ ...s, loading: false }));
+						return;
+					}
 					// Credentials expired during auto-refresh — disable admin mode quietly
 					currentAdminMode = false;
 					update((s) => ({
@@ -64,7 +73,7 @@ function createDisksStore() {
 			currentAdminMode = enabled;
 			update((s) => ({ ...s, adminMode: enabled }));
 		},
-		async mount(device: string, passphrase?: string, readOnly?: boolean, extraOptions?: string, ignorePermissions?: boolean): Promise<'success' | 'encryption_required' | 'error'> {
+		async mount(device: string, passphrase?: string, readOnly?: boolean, extraOptions?: string, ignorePermissions?: boolean): Promise<'success' | 'encryption_required' | 'cancelled' | 'error'> {
 			// Reject if this specific device is already being mounted
 			const current = get({ subscribe });
 			if (current.mountingDevices.has(device)) return 'error';
@@ -80,42 +89,72 @@ function createDisksStore() {
 			logAction('Mount started', { device });
 			update((s) => {
 				const devices = new Set(s.mountingDevices);
+				const messages = new Map(s.mountingMessages);
 				devices.add(device);
-				return { ...s, mountingDevices: devices, error: null, recentUnmount: false };
+				messages.set(
+					device,
+					get(elevation).policy.mode === 'interactive_terminal'
+						? 'Waiting for administrator approval and disk passphrase in Terminal…'
+						: 'Mounting…'
+				);
+				return {
+					...s,
+					mountingDevices: devices,
+					mountingMessages: messages,
+					error: null,
+					recentUnmount: false
+				};
 			});
 			try {
-				await mountDisk(device, passphrase, readOnly, extraOptions, ignorePermissions);
-				logAction('Mount completed', { device });
-				update((s) => {
-					const devices = new Set(s.mountingDevices);
-					devices.delete(device);
-					return { ...s, mountingDevices: devices };
-				});
-				notifyIfHidden('Mount Complete', `${device} mounted successfully.`);
-				return 'success';
-			} catch (e) {
-				const rawError = String(e);
-
-				// Detect encryption-required error from backend
-				if (rawError.includes('ENCRYPTION_REQUIRED')) {
+				const result = await mountDisk(device, passphrase, readOnly, extraOptions, ignorePermissions);
+				if (result.outcome === 'mounted') {
+					logAction('Mount completed', { device });
+					notifyIfHidden('Mount Complete', `${device} mounted successfully.`);
+					return 'success';
+				}
+				if (result.outcome === 'encryption_required') {
 					logAction('Encryption detected, passphrase needed', { device });
-					update((s) => {
-						const devices = new Set(s.mountingDevices);
-						devices.delete(device);
-						return { ...s, mountingDevices: devices };
-					});
 					return 'encryption_required';
 				}
+				if (result.outcome === 'cancelled') {
+					logAction('Mount cancelled', { device });
+					return 'cancelled';
+				}
 
+				const errorMessage = result.message || 'Mount failed';
+				logError('mount', new Error(errorMessage));
+				notifyIfHidden('Mount Failed', errorMessage);
+				update((s) => ({ ...s, error: errorMessage }));
+				return 'error';
+			} catch (e) {
 				logError('mount', e);
 				const errorMessage = parseError(e).message;
 				notifyIfHidden('Mount Failed', errorMessage);
+				update((s) => ({ ...s, error: errorMessage }));
+				return 'error';
+			} finally {
 				update((s) => {
 					const devices = new Set(s.mountingDevices);
+					const messages = new Map(s.mountingMessages);
 					devices.delete(device);
-					return { ...s, error: errorMessage, mountingDevices: devices };
+					messages.delete(device);
+					return { ...s, mountingDevices: devices, mountingMessages: messages };
 				});
-				return 'error';
+			}
+		},
+		async cancelMount(device: string): Promise<void> {
+			update((s) => {
+				if (!s.mountingDevices.has(device)) return s;
+				const messages = new Map(s.mountingMessages);
+				messages.set(device, 'Cancelling mount and requesting cleanup…');
+				return { ...s, mountingMessages: messages };
+			});
+			try {
+				await cancelElevationOperation(device);
+			} catch (error) {
+				const errorMessage = parseError(error).message;
+				logError('cancelMount', error);
+				update((s) => ({ ...s, error: errorMessage }));
 			}
 		},
 		async unmount(device?: string) {

--- a/src/lib/stores/disks.ts
+++ b/src/lib/stores/disks.ts
@@ -11,6 +11,7 @@ interface DisksState {
 	loading: boolean;
 	error: string | null;
 	mountingDevices: Set<string>;
+	cancellableMounts: Set<string>;
 	mountingMessages: Map<string, string>;
 	adminMode: boolean;
 	hasSupportedPartitions: boolean;
@@ -26,6 +27,7 @@ function createDisksStore() {
 		loading: false,
 		error: null,
 		mountingDevices: new Set(),
+		cancellableMounts: new Set(),
 		mountingMessages: new Map(),
 		adminMode: false,
 		hasSupportedPartitions: true,
@@ -33,40 +35,54 @@ function createDisksStore() {
 	});
 
 	let unmountTimeout: ReturnType<typeof setTimeout> | null = null;
+	let refreshPromise: Promise<void> | null = null;
 
 	return {
 		subscribe,
 		async refresh(useSudo?: boolean, silent?: boolean) {
-			update((s) => ({ ...s, loading: true, error: null }));
-			try {
-				const adminMode = useSudo ?? currentAdminMode;
-				const result = await listDisks(adminMode, silent ?? false);
-				update((s) => ({
-					...s,
-					disks: result.disks,
-					hasSupportedPartitions: result.has_supported_partitions,
-					loading: false
-				}));
-			} catch (e) {
-				const rawError = String(e);
-				if (silent && rawError.includes('ALFS_SILENT_AUTH_EXPIRED')) {
-					if (get(elevation).policy.mode === 'interactive_terminal') {
-						// Managed elevation requires visible interaction. Keep the
-						// current list until the user explicitly clicks Refresh.
-						update((s) => ({ ...s, loading: false }));
-						return;
-					}
-					// Credentials expired during auto-refresh — disable admin mode quietly
-					currentAdminMode = false;
+			// Disk-watcher and user refreshes share one backend operation. Coalesce
+			// overlapping requests so a silent refresh cannot clear the loading state
+			// of a visible Terminal request or launch a duplicate Terminal session.
+			if (refreshPromise) return refreshPromise;
+
+			refreshPromise = (async () => {
+				update((s) => ({ ...s, loading: true, error: null }));
+				try {
+					const adminMode = useSudo ?? currentAdminMode;
+					const result = await listDisks(adminMode, silent ?? false);
 					update((s) => ({
 						...s,
-						adminMode: false,
-						loading: false,
-						error: 'Admin credentials expired. Re-enable Admin mode to authenticate again.'
+						disks: result.disks,
+						hasSupportedPartitions: result.has_supported_partitions,
+						loading: false
 					}));
-					return;
+				} catch (e) {
+					const rawError = String(e);
+					if (silent && rawError.includes('ALFS_SILENT_AUTH_EXPIRED')) {
+						if (get(elevation).policy.mode === 'interactive_terminal') {
+							// Interactive elevation requires visible interaction. Keep the
+							// current list until the user explicitly clicks Refresh.
+							update((s) => ({ ...s, loading: false }));
+							return;
+						}
+						// Credentials expired during auto-refresh — disable admin mode quietly
+						currentAdminMode = false;
+						update((s) => ({
+							...s,
+							adminMode: false,
+							loading: false,
+							error: 'Admin credentials expired. Re-enable Admin mode to authenticate again.'
+						}));
+						return;
+					}
+					update((s) => ({ ...s, error: parseError(e).message, loading: false }));
 				}
-				update((s) => ({ ...s, error: parseError(e).message, loading: false }));
+			})();
+
+			try {
+				await refreshPromise;
+			} finally {
+				refreshPromise = null;
 			}
 		},
 		setAdminMode(enabled: boolean) {
@@ -87,19 +103,23 @@ function createDisksStore() {
 			}
 
 			logAction('Mount started', { device });
+			const elevationMode = get(elevation).policy.mode;
 			update((s) => {
 				const devices = new Set(s.mountingDevices);
+				const cancellableMounts = new Set(s.cancellableMounts);
 				const messages = new Map(s.mountingMessages);
 				devices.add(device);
+				if (elevationMode === 'interactive_terminal') cancellableMounts.add(device);
 				messages.set(
 					device,
-					get(elevation).policy.mode === 'interactive_terminal'
+					elevationMode === 'interactive_terminal'
 						? 'Waiting for administrator approval and disk passphrase in Terminal…'
 						: 'Mounting…'
 				);
 				return {
 					...s,
 					mountingDevices: devices,
+					cancellableMounts,
 					mountingMessages: messages,
 					error: null,
 					recentUnmount: false
@@ -135,10 +155,12 @@ function createDisksStore() {
 			} finally {
 				update((s) => {
 					const devices = new Set(s.mountingDevices);
+					const cancellableMounts = new Set(s.cancellableMounts);
 					const messages = new Map(s.mountingMessages);
 					devices.delete(device);
+					cancellableMounts.delete(device);
 					messages.delete(device);
-					return { ...s, mountingDevices: devices, mountingMessages: messages };
+					return { ...s, mountingDevices: devices, cancellableMounts, mountingMessages: messages };
 				});
 			}
 		},

--- a/src/lib/stores/elevation.ts
+++ b/src/lib/stores/elevation.ts
@@ -11,8 +11,7 @@ interface ElevationState {
 }
 
 const defaultPolicy: ElevationPolicy = {
-	mode: 'native',
-	locked: false
+	mode: 'native'
 };
 
 function createElevationStore() {

--- a/src/lib/stores/elevation.ts
+++ b/src/lib/stores/elevation.ts
@@ -1,0 +1,62 @@
+import { writable } from 'svelte/store';
+import type { ElevationMode, ElevationPolicy } from '../types';
+import { getElevationPolicy, setElevationMode } from '../api';
+import { parseError } from '../errors';
+
+interface ElevationState {
+	policy: ElevationPolicy;
+	loading: boolean;
+	saving: boolean;
+	error: string | null;
+}
+
+const defaultPolicy: ElevationPolicy = {
+	mode: 'native',
+	locked: false
+};
+
+function createElevationStore() {
+	const { subscribe, update } = writable<ElevationState>({
+		policy: defaultPolicy,
+		loading: false,
+		saving: false,
+		error: null
+	});
+
+	return {
+		subscribe,
+		async load() {
+			update((state) => ({ ...state, loading: true, error: null }));
+			try {
+				const policy = await getElevationPolicy();
+				update((state) => ({ ...state, policy, loading: false }));
+			} catch (error) {
+				update((state) => ({
+					...state,
+					loading: false,
+					error: parseError(error).message
+				}));
+			}
+		},
+		async setMode(mode: ElevationMode): Promise<boolean> {
+			update((state) => ({ ...state, saving: true, error: null }));
+			try {
+				const policy = await setElevationMode(mode);
+				update((state) => ({ ...state, policy, saving: false }));
+				return true;
+			} catch (error) {
+				update((state) => ({
+					...state,
+					saving: false,
+					error: parseError(error).message
+				}));
+				return false;
+			}
+		},
+		clearError() {
+			update((state) => ({ ...state, error: null }));
+		}
+	};
+}
+
+export const elevation = createElevationStore();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,20 @@ export interface AppConfig {
 	log_level: string | null;
 }
 
+export type ElevationMode = 'native' | 'interactive_terminal';
+
+export interface ElevationPolicy {
+	mode: ElevationMode;
+	locked: boolean;
+}
+
+export type MountOutcome = 'mounted' | 'encryption_required' | 'cancelled' | 'timed_out' | 'failed';
+
+export interface MountCommandResult {
+	outcome: MountOutcome;
+	message: string | null;
+}
+
 export interface CliStatus {
 	available: boolean;
 	path: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,7 +46,6 @@ export type ElevationMode = 'native' | 'interactive_terminal';
 
 export interface ElevationPolicy {
 	mode: ElevationMode;
-	locked: boolean;
 }
 
 export type MountOutcome = 'mounted' | 'encryption_required' | 'cancelled' | 'timed_out' | 'failed';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import Sidebar from '../components/Sidebar.svelte';
 	import { status } from '$lib/stores/status';
+	import { elevation } from '$lib/stores/elevation';
 	import { onMount, onDestroy } from 'svelte';
 	import type { Snippet } from 'svelte';
 
@@ -9,6 +10,7 @@
 
 	onMount(() => {
 		status.startListening();
+		elevation.load();
 	});
 
 	onDestroy(() => {


### PR DESCRIPTION
## Summary

- add a Rust-owned elevation policy with native sudo and Interactive Terminal modes
- run interactive elevation and encrypted-volume prompts through a protected Terminal PTY
- add structured mount outcomes, race-safe cancellable sessions, timeout/app-exit cleanup, and clearer GUI status
- retain native sudo as the default and serialize privileged refresh operations

## Motivation

Some macOS endpoint privilege managers approve `sudo` only from an interactive Terminal session. In that environment, the `anylinuxfs` CLI works after the organization's approval workflow, while the GUI's native PAM/`SUDO_ASKPASS` path is rejected. This is especially visible for LUKS volumes because elevation and the encryption passphrase are both interactive.

## Design and security

- The Rust backend is the single source of truth for elevation policy; the setting is persisted atomically in an owner-only preferences file.
- Terminal handoff directories are randomly named and owner-only, generated scripts are mode `0700`, and every command argument is shell-quoted after existing device/option validation.
- Secret-bearing mount commands use macOS `script -q /dev/null` as a bidirectional PTY relay. Terminal echo is disabled and restored by a cleanup trap. The LUKS/BitLocker passphrase is not placed in command arguments, environment variables, generated files, or an output transcript.
- Output capture is used only for non-secret discovery commands such as `list`.
- Sessions are registered before Terminal launch. The script publishes its PID and launch acknowledgement through atomic file replacement, then checks the cancel marker immediately before the command. Cancellation cleanup waits for delayed Terminal launch, terminates the handoff process tree, and requests device-specific `anylinuxfs stop <device>` cleanup.
- Elevation mode is snapshotted per operation and cannot change while privileged work is active. The frontend records cancellability per mount rather than deriving it from the current global preference.
- Frontend refresh requests are coalesced and the backend rejects a duplicate `list` operation, preventing disk-watcher refreshes from opening overlapping Terminal sessions.
- Confirmed persistent mounts are deliberately preserved when the GUI exits, matching the existing quit warning that active filesystems are not automatically unmounted.
- Mount results are returned as `mounted`, `encryption_required`, `cancelled`, `timed_out`, or `failed`, allowing the GUI to show actionable state and a Cancel control.

## Validation

- `cargo test`: 16 passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo check`: passed
- `npx svelte-check`: 0 errors and 0 warnings
- production frontend and macOS Tauri `.app` build: passed
- live managed-Mac regression with CyberArk and a whole-device LUKS/ext4 USB drive:
  - GUI unmount and Terminal/LUKS remount completed successfully
  - deliberate cancellation returned a structured cancelled result
  - cancelled Terminal, mount, and VM processes were cleaned up before retry
  - final `--ignore-permissions` remount completed successfully

## Review follow-up

Commit [`037c29d`](https://github.com/fenio/anylinuxfs-gui/commit/037c29df66d4c589fd3d61c71c8e124593d7e5d1) addresses the three review findings: pre-launch cancellation, mode stability/cancellability, and refresh serialization. It also removes the compile-time managed lock from the upstream change as requested; that enforcement remains downstream-only. This PR does not claim to resolve #108 or #114.
