### PR TITLE
fix: support BitLocker partitions

### DIFF
--- a/src-tauri/src/commands/disk.rs
+++ b/src-tauri/src/commands/disk.rs
@@ -248,7 +248,7 @@ fn is_linux_native_fs(fs: &str) -> bool {
         || fs_lower.contains("btrfs") || fs_lower.contains("xfs") || fs_lower.contains("f2fs")
         || fs_lower.contains("reiserfs") || fs_lower.contains("zfs")
         || fs_lower.contains("ntfs") || fs_lower.contains("exfat")
-        || fs_lower.contains("luks")
+        || fs_lower.contains("luks") || fs_lower.contains("bitlocker")
         || fs_lower.contains("lvm") || fs_lower.contains("raid")
         || fs_lower == "linux filesystem"
 }
@@ -264,9 +264,9 @@ fn check_filesystem_support(fs: &str) -> (bool, Option<String>) {
         return (true, None);
     }
 
-    // LUKS encrypted partitions — supported, passphrase will be requested at mount time
-    if fs_lower.contains("luks") {
-        return (true, Some("Encrypted (passphrase required)".to_string()));
+    // Encrypted partitions are supported; an unlock key is requested at mount time.
+    if fs_lower.contains("luks") || fs_lower.contains("bitlocker") {
+        return (true, Some("Encrypted (unlock key required)".to_string()));
     }
 
     // RAID/LVM member partitions — not directly mountable, use admin mode for actual volumes
@@ -762,5 +762,33 @@ mod tests {
 
         let devices: Vec<&str> = disk.partitions.iter().map(|p| p.device.as_str()).collect();
         assert_eq!(devices, vec!["/dev/disk6s1", "/dev/disk6s5"]);
+    }
+
+    /// Issue #133: the CLI identifies BitLocker directly, so diskutil's
+    /// misleading MS-DOS personality must not replace or disable it.
+    #[test]
+    fn bitlocker_partitions_are_encrypted_and_mountable() {
+        let output = "\
+/dev/disk6 (external, physical):
+   #:                       TYPE NAME                    SIZE       IDENTIFIER
+   0:      GUID_partition_scheme                        *2.0 TB     disk6
+   3:                  BitLocker Workstation Window...   706.4 GB   disk6s3
+   4:       Microsoft Basic Data Sharing                 104.9 GB   disk6s4
+   5:                  BitLocker Workstation Data 2...    1.2 TB     disk6s5
+";
+        let result = parse_disk_list_output(output).expect("parse should succeed");
+        let bitlocker: Vec<&Partition> = result.disks[0]
+            .partitions
+            .iter()
+            .filter(|partition| partition.filesystem == "BitLocker")
+            .collect();
+
+        assert_eq!(bitlocker.len(), 2);
+        assert!(bitlocker.iter().all(|partition| partition.encrypted));
+        assert!(is_linux_native_fs("BitLocker"));
+        assert_eq!(
+            check_filesystem_support("BitLocker"),
+            (true, Some("Encrypted (unlock key required)".to_string()))
+        );
     }
 }

--- a/src/components/DiskList.svelte
+++ b/src/components/DiskList.svelte
@@ -82,7 +82,7 @@
 				status.refresh();
 			} else if (result === 'encryption_required') {
 				// Wrong passphrase — keep dialog open with error
-				passphraseError = 'Incorrect passphrase. Please try again.';
+				passphraseError = 'Incorrect passphrase or recovery key. Please try again.';
 			} else {
 				// Other error — close dialog, error shown in main banner
 				passphraseDevice = null;

--- a/src/components/PassphraseDialog.svelte
+++ b/src/components/PassphraseDialog.svelte
@@ -42,7 +42,7 @@
 <div class="overlay" role="dialog" aria-modal="true" tabindex="-1" onkeydown={handleKeydown}>
 	<div class="dialog">
 		<div class="dialog-header">
-			<h3>Enter Passphrase</h3>
+			<h3>Unlock Encrypted Partition</h3>
 		</div>
 		<div class="dialog-body">
 			<p class="device-info">
@@ -52,14 +52,14 @@
 				<p class="passphrase-error" role="alert">{errorMessage}</p>
 			{/if}
 			<form onsubmit={handleSubmit}>
-				<label for="passphrase">Passphrase</label>
+				<label for="passphrase">Passphrase or recovery key</label>
 				<div class="input-wrapper">
 					<input
 						bind:this={inputEl}
 						id="passphrase"
 						type={showPassphrase ? 'text' : 'password'}
 						bind:value={passphrase}
-						placeholder="Enter encryption passphrase"
+						placeholder="Enter passphrase or recovery key"
 						autocomplete="off"
 						autocorrect="off"
 						spellcheck="false"


### PR DESCRIPTION
## Summary

- preserve BitLocker filesystem detection from `anylinuxfs list` instead of replacing it with diskutil's misleading MS-DOS personality
- classify BitLocker partitions as supported encrypted volumes so the mount controls and unlock flow are available
- clarify that BitLocker recovery keys are accepted by the encrypted-volume dialog
- add regression coverage using the disk layout reported in issue #133

## Root cause

The parser correctly identified `BitLocker`, but `is_linux_native_fs` did not consider it an authoritative CLI-detected format. The subsequent diskutil enrichment replaced it with `MS-DOS`, which was classified as an unknown FAT variant and disabled mounting.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `npx svelte-check`
- `npm run build`
- `git diff --check`

Fixes #133
